### PR TITLE
Intégration des commentaires avec Disqus

### DIFF
--- a/src/mkdocs/mkdocs.yml
+++ b/src/mkdocs/mkdocs.yml
@@ -48,7 +48,8 @@ google_analytics:
 
 # Customization
 extra:
-  manifest: 'manifest.webmanifest'
+  disqus: 'geotribu_static'  # comment system
+  manifest: 'manifest.webmanifest'  # PWA declaration
   social:
     - type: 'github'
       link: 'https://github.com/geotribu/'


### PR DESCRIPTION
A noter :

- c'est donc une dépendance à un service tiers
- formule gratuite donc pub (et sûrement tout le tracking qui vient avec)

Faudra réfléchir à la verison payante : https://disqus.com/pricing/