### PR TITLE
Correction du calcul des contributions par auteur

### DIFF
--- a/.github/workflows/deploy_master_to_github_pages.yml
+++ b/.github/workflows/deploy_master_to_github_pages.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
     - name: Get source code
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     - name: Set up Python 3.7
       uses: actions/setup-python@v1


### PR DESCRIPTION
Lors de la pahe de build en vue du déploiement, il est nécessaire de récupérer tout l'historique git pour caculer correctement les contributions de chaque auteur.

Voir https://github.com/timvink/mkdocs-git-revision-date-localized-plugin#when-using-ci-runners