### PR TITLE
Correction de l'article sur GIS Cloud

### DIFF
--- a/content/articles/2011/art_2011-11-09.md
+++ b/content/articles/2011/art_2011-11-09.md
@@ -1,28 +1,33 @@
 ---
-title: "A la découverte de Gis Cloud"
-authors: GeoTribu
+title: "A la découverte de GIS Cloud"
+authors: ["GeoTribu"]
 category: article
 date: 2011-11-09
+description: "Découverte de GIS Cloud, plateforme de création de contenu web-cartographique dont on entend beaucoup parler ces derniers temps. Bien décidé à voir de quoi il en retourne, je me suis inscrit et j'en ai profité pour faire quelques tests. Je vous livre ci-dessous mes impressions."
+image: "URL de l'image d'illustration de la RDP"
 tags: HTML 5 | GIS Cloud
 ---
 
-# A la découverte de Gis Cloud
-
+# A la découverte de GIS Cloud
 
 :calendar: Date de publication initiale : 09 novembre 2011
 
 **Mots-clés :** HTML 5 | GIS Cloud
 
+![giscloud_logo.jpg](https://cdn.geotribu.fr/img/articles-blog-rdp/serveur/giscloud/giscloud_logo.jpg){: .img-rdp-news-thumb }
 
-![giscloud_logo.jpg](http://www.geotribu.net/sites/default/files/Tuto/img/Blog/giscloud/giscloud_logo.jpg)Cela faisait plusieurs semaines que ma [timeline twitter](http://twitter.com/#!/geotribu) s'ornait de hashtag [GisCloud](http://www.giscloud.com). C'est vrai que les différentes [démos](http://www.giscloud.com/blog/gis-cloud-starts-html5-mapping-revolution) proposées sont tout de même impressionnantes. J'entends déjà les amoureux de la sémiologie graphique me dire que c'est une hérésie d'afficher 1 million de points sur une carte. Sur ce point, je suis tout à fait d'accord. Néanmoins, la prouesse technique est tout de même bluffante ! Du coup, bien décidé à voir de quoi il en retourne, je me suis inscrit et j'en ai profité pour faire quelques tests. Je vous livre ci-dessous mes impressions.
+Cela faisait plusieurs semaines que ma [timeline twitter](http://twitter.com/#!/geotribu) s'ornait de hashtag [GisCloud](http://www.giscloud.com). C'est vrai que les différentes [démos](http://www.giscloud.com/blog/gis-cloud-starts-html5-mapping-revolution) proposées sont tout de même impressionnantes. J'entends déjà les amoureux de la sémiologie graphique me dire que c'est une hérésie d'afficher 1 million de points sur une carte. Sur ce point, je suis tout à fait d'accord. Néanmoins, la prouesse technique est tout de même bluffante ! Du coup, bien décidé à voir de quoi il en retourne, je me suis inscrit et j'en ai profité pour faire quelques tests.
 
-### Présentation générale
+Je vous livre ci-dessous mes impressions.
 
-Tout d'abord, vous vous demandez certainement qu'est-ce que Gis Cloud ? Il s'agit d'une infrastructure permettant :
+## Présentation générale
+
+Tout d'abord, vous vous demandez certainement qu'est-ce que GIS Cloud ? Il s'agit d'une infrastructure permettant :
 
 * d'une part la création et l'hébergement d'applications cartographiques ;
 * et d'autre part l'accès à ces applications grâce à une une [API Javascript](http://dev.giscloud.com/JavaScriptApi/) et une [API Rest](http://dev.giscloud.com/RestGuide).
-Les [fonctionnalités](http://www.giscloud.com/features/) de Gis Cloud s'orientent en fonction des [six axes majeurs](http://www.giscloud.com/features/) suivants :
+
+Les [fonctionnalités](http://www.giscloud.com/features/) de GIS Cloud s'orientent en fonction des [six axes majeurs](http://www.giscloud.com/features/) suivants :
 
 * [Outils cartographiques collaboratifs](http://www.giscloud.com/features/collaboration-map-management)
 * [Partage et publication de cartes sur Internet](http://www.giscloud.com/features/share-and-publish-on-web)
@@ -30,73 +35,93 @@ Les [fonctionnalités](http://www.giscloud.com/features/) de Gis Cloud s'oriente
 * [Cartographies thématiques](http://www.giscloud.com/features/thematic-maps-analysis)
 * [Intégration aux systèmes déjà existants](http://www.giscloud.com/features/integrate-with-existing-systems/)
 * [Cloud personnel](http://www.giscloud.com/features/personal-cloud/)
+
 La [liste complète](http://www.giscloud.com/full-feature-list/) des fonctionnalités est bien trop exhaustive pour que je vous la cite içi. Néanmoins, n'hésitez pas à y jeter un coup d'œil pour avoir plus d'informations.
 
-Après cette brève présentation, entrons dans le vif du sujet et voyons voir ce qui se cache derrière Gis Cloud.
+Après cette brève présentation, entrons dans le vif du sujet et voyons voir ce qui se cache derrière GIS Cloud.
 
-### Création cartographique
+## Création cartographique
 
 Une fois mon inscription réalisée, je peux maintenant accéder à l'interface de création cartographique. C'est à partir de celle-ci que nous allons importer nos données, spécifier le style désiré, etc. Toutes les possibilités sont expliquées dans la [documentation](http://www.giscloud.com/docs/).
 
-![interface_interface.png](http://geotribu.net/sites/default/files/Tuto/img/Blog/giscloud/interface_interface.png)
+![interface_interface.png](https://cdn.geotribu.fr/img/articles-blog-rdp/serveur/giscloud/giscloud_interface.png){: loading=lazy }
 
 Me voilà maintenant prêt à créer une nouvelle carte. La première étape est bien évidemment d'ajouter les données désirées. Dans un premier temps, je vais commencer par ajouter un fond de carte. Au choix vous avez, Google Maps (maps, satellite, terrain), 3Tier Wind 80m, Bing Maps ou encore Open Street Map. Bien évidemment, mon choix s'est porté sur ce dernier.
 
-![osm_data.png](http://geotribu.net/sites/default/files/Tuto/img/Blog/giscloud/osm_data.png)
+![osm_data.png](https://cdn.geotribu.fr/img/articles-blog-rdp/serveur/giscloud/osm_data.png){: loading=lazy }
 
-Passons maintenant à nos données vecteurs. La liste des formats qu'il est possible d'importer, sans être exhaustive, est néanmoins suffisante. En effet, Gis Cloud permet l'accès aux fichiers Shapefile, MapInfo, KML, CSV, PNG, etc. Pour les besoins de notre test, j'ai téléchargé les données [OpenStreetMap](https://www.openstreetmap.org/) au [format Shapefile](http://download.geofabrik.de/osm/europe/france/) proposé par [GeoFabrik](http://www.geofabrik.de/). Étant donné le poids de mes fichiers (+ de 200 Mo) l'import prend un peu de temps. Croisez les doigts en espérant que tout se passe bien et au bout d'une heure la liste de vos fichiers apparaît enfin. Vous n'avez plus qu'à sélectionner la couche désirée et à l'ajouter à l'interface. Attention, là encore cela peut prendre pas mal de temps !
+Passons maintenant à nos données vecteurs. La liste des formats qu'il est possible d'importer, sans être exhaustive, est néanmoins suffisante. En effet, GIS Cloud permet l'accès aux fichiers Shapefile, MapInfo, KML, CSV, PNG, etc. Pour les besoins de notre test, j'ai téléchargé les données [OpenStreetMap](https://www.openstreetmap.org/) au [format Shapefile](http://download.geofabrik.de/osm/europe/france/) proposé par [GeoFabrik](http://www.geofabrik.de/). Étant donné le poids de mes fichiers (+ de 200 Mo) l'import prend un peu de temps. Croisez les doigts en espérant que tout se passe bien et au bout d'une heure la liste de vos fichiers apparaît enfin. Vous n'avez plus qu'à sélectionner la couche désirée et à l'ajouter à l'interface. Attention, là encore cela peut prendre pas mal de temps !
 
-![data_osm_shp.png](http://geotribu.net/sites/default/files/Tuto/img/Blog/giscloud/data_osm_shp.png)
+![data_osm_shp.png](https://cdn.geotribu.fr/img/articles-blog-rdp/serveur/giscloud/data_osm_shp.png){: loading=lazy }
 
 En plus des fichiers classiques, vous pouvez également connecter une base de données PostGis. Néanmoins, c'est une base de données locale. L’intérêt est donc un peu limité. Mais pour le test, j'ai intégré la couche de points des données OSM.
 
-![postgis_db.png](http://geotribu.net/sites/default/files/Tuto/img/Blog/giscloud/postgis_db.png)
+![postgis_db.png](https://cdn.geotribu.fr/img/articles-blog-rdp/serveur/giscloud/postgis_db.png){: loading=lazy }
 
 Me voici maintenant avec ma carte et mes données. Profitons-en pour modifier la symbologie des couches.
 
-![styling.png](http://www.geotribu.net/sites/default/files/Tuto/img/Blog/giscloud/styling.png)
+![styling.png](https://cdn.geotribu.fr/img/articles-blog-rdp/serveur/giscloud/styling.png){: loading=lazy }
 
 Et voilà, tout est correctement paramétré. Il me reste maintenant à publier mon projet pour qu'il soit accessible sur le web.
 
-### Publication du projet
+## Publication du projet
 
 Une fois mon projet configuré comme je le souhaite, il me suffit maintenant de le publier sur le web. Pour cela différentes options sont possibles. Tout d'abord, je peux tout simplement fournir le [lien permanent](http://www.giscloud.com/map/19062/openstreetmappaca). Les utilisateurs auront alors accès à mon projet au travers de l'interface de la plateforme GisCloud. Mais, une intégration plus poussée est également possible. En effet, vous pouvez (par ordre de difficulté) ajouter votre projet à une page web sous la forme d'une iframe, intégrer le flux Web Map Service (WMS) généré, ou alors coder une application grâce à l'API Javascript.
 
-Testons immédiatement l'iframe. Il me suffit donc de spécifier l'URL de GisCloud ainsi que l'ID de mon projet pour voir ma carte s'afficher. Il est également possible d'ajouter un arbre des couches avec l'option layerlist=true, ou une barre d'outils avec l'option toolbar=true.
+Testons immédiatement l'iframe. Il me suffit donc de spécifier l'URL de GisCloud ainsi que l'ID de mon projet pour voir ma carte s'afficher. Il est également possible d'ajouter un arbre des couches avec l'option layerlist=true, ou une barre d'outils avec l'option `toolbar=true`.
 
-![gisCloud_embed.png](http://www.geotribu.net/sites/default/files/Tuto/img/Blog/giscloud/gisCloud_embed.png)
+![gisCloud_embed.png](https://cdn.geotribu.fr/img/articles-blog-rdp/serveur/giscloud/gisCloud_embed.png){: loading=lazy }
 
 Et voilà, en quelques secondes, mon projet est publié :
 
+<iframe src="https://app.giscloud.com/rest/1/maps/19062/render.iframe?map=19062&bound=809726.1045104787,5420082.793302087,817035.395340249,5417216.404741392" title="GIS Cloud test" height="500px"></iframe>
 
+## Flux WMS
 
-### Flux WMS
+Mais, peut-être souhaitez-vous simplement diffuser vos couches sur le net sans pour autant vous embarrasser d'une application cartographique. Dans ce cas, il vous suffira de rendre public le flux WMS généré par GisCloud. J'entre alors l'url du WMS dans QGIS mais j'obtiens une erreur !
 
-Mais, peut-être souhaitez-vous simplement diffuser vos couches sur le net sans pour autant vous embarrasser d'une application cartographique. Dans ce cas, il vous suffira de rendre public le flux WMS généré par GisCloud. J'entre alors l'url du WMS dans QGIS mais j'obtiens une erreur ! Au départ, je pensais que QGIS était en cause mais après avoir tapé un getCapabilities du WMS dans mon navigateur, j'ai toujours cette même erreur (voir ci-dessous). Cela proviendrait donc de GisCloud. Je retenterai l'expérience dans quelques jours pour voir cela ne provient pas d'un simple incident technique isolé.
+Au départ, je pensais que QGIS était en cause mais après avoir tapé un `getCapabilities` du WMS dans mon navigateur, j'ai toujours cette même erreur :
 
-RuntimeError: failed to initialize projection with:+init=epsg:901023  
+`RuntimeError: failed to initialize projection with:+init=epsg:901023`
 
-### API Javascript
+Cela proviendrait donc de GisCloud. Je retenterai l'expérience dans quelques jours pour voir cela ne provient pas d'un simple incident technique isolé.
 
-Dernier moyen d'intégrer une carte GisCloud, son [API Javascript](http://dev.giscloud.com/JavaScriptApi/ApiReference). En effet, si vous le souhaitez, vous pouvez coder votre propre application cartographique. Pour cela, commencez par lire le [tutoriel](http://dev.giscloud.com/JavaScriptApi/GettingStarted) qui vous guidera dans vos premiers pas et n'hésitez pas non plus à consulter les [différents exemples](https://github.com/giscloud/GIS-Cloud-Examples) disponibles. Celui sur les [markers](http://dev.giscloud.com/examples/markermethods.html) est bien sympathique. Je me demande si je ne vais pas copier l'idée et essayer de faire quelque chose de similaire pour OpenLayers. Mais bon, là n'est pas le sujet de cet article, revenons à notre API Javascript. Pour cela, nous allons tout simplement afficher notre carte précédemment créée. Une fois ma page correctement configurée, cela se fait en à peine une ligne de code :
+## API Javascript
 
+Dernier moyen d'intégrer une carte GisCloud, son [API Javascript](http://dev.giscloud.com/JavaScriptApi/ApiReference).
+
+En effet, si vous le souhaitez, vous pouvez coder votre propre application cartographique. Pour cela, commencez par lire le [tutoriel](http://dev.giscloud.com/JavaScriptApi/GettingStarted) qui vous guidera dans vos premiers pas et n'hésitez pas non plus à consulter les [différents exemples](https://github.com/giscloud/GIS-Cloud-Examples) disponibles. Celui sur les [markers](http://dev.giscloud.com/examples/markermethods.html) est bien sympathique.
+
+Je me demande si je ne vais pas copier l'idée et essayer de faire quelque chose de similaire pour OpenLayers. Mais bon, là n'est pas le sujet de cet article, revenons à notre API Javascript. Pour cela, nous allons tout simplement afficher notre carte précédemment créée. Une fois ma page correctement configurée, cela se fait en à peine une ligne de code :
+
+```js
 simple mapping app example
+```
 
 Le résultat obtenu est le suivant :
 
-[![api_1.png](http://www.geotribu.net/sites/default/files/Tuto/img/Blog/giscloud/api_1.png)](http://www.geotribu.net/applications/gisCloud/map1.html)
+[![api_1.png](https://cdn.geotribu.fr/img/articles-blog-rdp/serveur/giscloud/api_1.png)](https://web.archive.org/web/http://www.geotribu.net/applications/gisCloud/map1.html)
 
 Allez, ajoutons maintenant une barre d'outils :
 
-giscloud.ready(function() { // create a viewer var viewer = new giscloud.Viewer("map", 19062, { slider: true }); // create a toolbar var toolbar = new giscloud.ui.Toolbar({ viewer: viewer, container: "toolbar", defaultTools: ["pan", "zoom", "full"] }); });
+```js
+giscloud.ready(function () {
+    // create a viewer
+    var viewer = new giscloud.Viewer("map", 19062, { slider: true }); // create a toolbar
+    var toolbar = new giscloud.ui.Toolbar({
+        viewer: viewer,
+        container: "toolbar", defaultTools: ["pan", "zoom", "full"]
+    });
+});
+```
 
 Et voilà en image le résultat. Notez, la barre d'outils en haut à gauche :
 
-[![api_map2.png](http://www.geotribu.net/sites/default/files/Tuto/img/Blog/giscloud/api_map2.png)](http://www.geotribu.net/applications/gisCloud/map2.html)
+[![api_map2.png](https://cdn.geotribu.fr/img/articles-blog-rdp/serveur/giscloud/api_map2.png)](https://web.archive.org/web/http://www.geotribu.net/applications/gisCloud/map2.html)
 
 Bien évidemment, ces deux exemples sont insuffisants pour montrer l'étendue de l'API proposée. Mais l'objectif était simplement de présenter les différents modes d'intégration possibles.
 
-### Conclusion
+## Conclusion
 
 Notre rapide tour de GisCloud est maintenant terminé et vient donc l'heure des conclusions. Je dois avouer que j'ai été agréablement surpris par l'interface de création cartographique. Elle est intuitive et il est facile d'arriver en quelques minutes aux résultats escomptés. Les différents modes d'intégration sont également un point à souligner. Ainsi, l'utilisateur lambda comme le programmeur y trouveront leur bonheur.
 
@@ -107,15 +132,15 @@ Au moment où j'ai effectué mes tests, GisCloud était encore en bêta. Mais, j
 * Un seul service WMS
 * Limitations au niveau de l'API
 * Limitations également pour la publication et la collaboration
+
 Même si je trouve tout à fait normal que cette entreprise développe son business model, les conditions pour la version gratuite sont tout de même très limitées. C'est dommage car à mon avis, ils auraient gagné à s'ouvrir un peu plus. En effet, cela aurait permis d'attirer plus de personnes et donc potentiellement de nouveaux clients. Il suffit de voir la stratégie de Google à ce sujet qui commence également à monétiser ces services. Quoi qu'il en soit, c'est vraiment un bon produit. Mais cela suffira-t-il pour se démarquer de la concurrence face à des projets similaires tels que [GeoCommons](http://geocommons.com) ? Nous tenterons de répondre à cette question dans un prochain billet.
-
-
 
 ----
 
 ## Auteur
 
+### GeoTribu
+
 ![Portait de GeoTribu](https://cdn.geotribu.fr/images/internal/charte/geotribu\_logo\_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
 
 Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ plugins:
   - redirects:
       redirect_maps:
         "dicogis.md": "articles/2014/art_2014-09-25_dicogis.md"
+        "node/462.md": "articles/2011/art_2011-11-09.md"
         "node/636.md": "articles/2013/art_2013-09-26.md"
         "rdp/rdp_2020-04-30.md": "rdp/2020/rdp_2020-04-30.md"
 


### PR DESCRIPTION
Erreur 500 remontée par la console Google sur l'article de @arno974 :

![image](https://user-images.githubusercontent.com/1596222/95013999-45970500-0644-11eb-9e1c-e845457d81e1.png)

Corrections :

- ajout d'une redirection depuis l'ancien site http://geotribu.net:80/node/462, visible ici dans l'Internet Archive https://web.archive.org/web/20170804023040/http://geotribu.net:80/node/462
- correction de la syntaxe et des liens vers les images