### PR TITLE
RSS - Use publication dates instead of git log

### DIFF
--- a/content/rdp/2020/rdp_2020-05-15.md
+++ b/content/rdp/2020/rdp_2020-05-15.md
@@ -2,7 +2,7 @@
 title: "Revue de presse du 15 mai 2020"
 authors: ["Geotribu"]
 categories: ["Revues de presse"]
-date: 2020-15-08 10:20
+date: 2020-05-08 10:20
 description: "#GeoRDP du 15 mai 2020 : projection, GRASS, pyrosm, gdal, FME 2020, geopackage, qgis, geoserver, geomapfish"
 image: "https://cdn.geotribu.fr/img/articles-blog-rdp/capture-ecran/mercator_scandale_bd.jpg"
 tags: rdp,python,geoserver,osm,gdal,geomapfish,python,grass,qgis

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,10 @@ plugins:
         remove_comments: true
   - rss:
       abstract_chars_count: 500
+      date_from_meta:
+        as_creation: "date"
+        as_update: false
+        datetime_format: "%Y-%m-%d %H:%M"
       image: "https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png"
       length: 50
   - search:

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,4 @@ mkdocs-git-revision-date-localized-plugin>=0.6,<0.8
 mkdocs-material>=5.4,<6.2
 mkdocs-minify-plugin==0.3.*
 mkdocs-redirects==1.0.*
-mkdocs-rss-plugin>=0.3,<0.10
+mkdocs-rss-plugin>=0.3,<0.11


### PR DESCRIPTION
Depuis la version 0.10.0 du plugin RSS (https://github.com/Guts/mkdocs-rss-plugin), il est possible de préférer les dates spécifiées manuellement dans l'en-tête de la page (YAML front-matter) plutôt que celles de l'historique git.

Par exemple pour que la date du flux soit celle de publication et non du premier commit, ce qui est utile dans notre processus de rédaction, notamment pour les revues de presse.

