### PR TITLE
Exclude contents

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,11 @@ site_dir: './build/mkdocs/site'
 # Plugins
 plugins:
   - awesome-pages
+  - exclude:
+      glob:
+        - "content/articles/templates/*"
+        - "content/**/_*.md"
+        - "*.yml"
   - git-authors:
       show_contribution: true
   - git-revision-date-localized:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,8 +23,7 @@ plugins:
   - awesome-pages
   - exclude:
       glob:
-        - "content/articles/templates/*"
-        - "content/**/_*.md"
+        - "*/templates/*"
         - "*.yml"
   - git-authors:
       show_contribution: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,9 +13,10 @@ pre-commit>=2.5,<2.10
 # -----------------------
 
 mkdocs-awesome-pages-plugin>=2.4,<2.6
+mkdocs-exclude>=1.0,<1.1
 mkdocs-git-authors-plugin==0.3.*
 mkdocs-git-revision-date-localized-plugin>=0.6,<0.9
 mkdocs-material>=6.0,<6.3
 mkdocs-minify-plugin==0.3.*
 mkdocs-redirects==1.0.*
-mkdocs-rss-plugin>=0.3,<0.11
+mkdocs-rss-plugin>=0.10,<0.12


### PR DESCRIPTION
Ajoute le plugin https://github.com/apenwarr/mkdocs-exclude/ pour éviter de retrouver des fichiers non souhaités dans le rendu final :

- exclut les fichiers de configuration spécifiques à la contribution
- exclut les modèles de contribution