### PR TITLE
Article vectipy : complement, autres serveurs

### DIFF
--- a/content/articles/2021/2021-04-26_vectipy_postgis_mvt.md
+++ b/content/articles/2021/2021-04-26_vectipy_postgis_mvt.md
@@ -174,11 +174,8 @@ Voir aussi :
 - [Les tuiles vectorielles](https://docs.mapbox.com/vector-tiles/specification/)
 - [PostGIS : ST_AsMVT](https://postgis.net/docs/ST_AsMVT.html)
 
-Autres serveurs de tuiles vectorielles :
+Autres serveurs de tuiles vectorielles sur le [Github de Mapbox](https://github.com/mapbox/awesome-vector-tiles#servers)
 
-- [T-rex](https://t-rex.tileserver.ch/)
-- [pg_tileserver](https://github.com/CrunchyData/pg_tileserv)
-- [Tegola](https://tegola.io/)
 
 ----
 

--- a/content/articles/2021/2021-04-26_vectipy_postgis_mvt.md
+++ b/content/articles/2021/2021-04-26_vectipy_postgis_mvt.md
@@ -174,6 +174,12 @@ Voir aussi :
 - [Les tuiles vectorielles](https://docs.mapbox.com/vector-tiles/specification/)
 - [PostGIS : ST_AsMVT](https://postgis.net/docs/ST_AsMVT.html)
 
+Autres serveurs de tuiles vectorielles :
+
+- [T-rex](https://t-rex.tileserver.ch/)
+- [pg_tileserver](https://github.com/CrunchyData/pg_tileserv)
+- [Tegola](https://tegola.io/)
+
 ----
 
 ## Auteur

--- a/content/articles/2021/2021-04-26_vectipy_postgis_mvt.md
+++ b/content/articles/2021/2021-04-26_vectipy_postgis_mvt.md
@@ -176,7 +176,6 @@ Voir aussi :
 
 Autres serveurs de tuiles vectorielles sur le [Github de Mapbox](https://github.com/mapbox/awesome-vector-tiles#servers)
 
-
 ----
 
 ## Auteur


### PR DESCRIPTION
Ajout d'un complément sur l'article Vectipy (liste d'autres serveurs de tuiles existants) suite aux différents retour sur twitter.