### PR TITLE
GeoRDP du 4 juin 2021 - Cartographier les émissions de gaz a effet de serre

### DIFF
--- a/content/rdp/2021/rdp_2021-06-04.md
+++ b/content/rdp/2021/rdp_2021-06-04.md
@@ -127,7 +127,7 @@ Et que [PostGIS](http://postgis.net) s’est rapidement imposé comme une brique
 
 ### Cartographier les émissions de gaz à effet de serre
 
-Cédric Rossi (@cedricr) propose dans le carnet de recherches [Néocarto](https://neocarto.hypotheses.org), une série intéressante de [trois billets](https://neocarto.hypotheses.org/13482) portant sur la cartographie des émissions de gaz à effet de serre, en France et en Europe. 
+Cédric Rossi (@cedricr) propose dans le carnet de recherches [Néocarto](https://neocarto.hypotheses.org), une série intéressante de [trois billets](https://neocarto.hypotheses.org/13482) portant sur la cartographie des émissions de gaz à effet de serre, en France et en Europe.
 
 Il partage également le .qpt du Template de sa carte [France entière avec les DROM à l'échelle](https://layout-hub.github.io/layout-dir/FranceDROM.qpt) sur le [hub QGIS](https://layout-hub.github.io/)
 

--- a/content/rdp/2021/rdp_2021-06-04.md
+++ b/content/rdp/2021/rdp_2021-06-04.md
@@ -127,9 +127,10 @@ Et que [PostGIS](http://postgis.net) s’est rapidement imposé comme une brique
 
 ### Cartographier les émissions de gaz à effet de serre
 
-Série intéressante et partage du qpt sur le hub QGIS
+Cédric Rossi (@cedricr) propose dans le carnet de recherches [Néocarto](https://neocarto.hypotheses.org), une série intéressante de [trois billets](https://neocarto.hypotheses.org/13482) portant sur la cartographie des émissions de gaz à effet de serre, en France et en Europe. 
 
-<https://neocarto.hypotheses.org/category/autre/carto-crititique>
+Il partage également le .qpt du Template de sa carte [France entière avec les DROM à l'échelle](https://layout-hub.github.io/layout-dir/FranceDROM.qpt) sur le [hub QGIS](https://layout-hub.github.io/)
+
 
 ----
 

--- a/content/rdp/2021/rdp_2021-06-04.md
+++ b/content/rdp/2021/rdp_2021-06-04.md
@@ -127,10 +127,13 @@ Et que [PostGIS](http://postgis.net) s’est rapidement imposé comme une brique
 
 ### Cartographier les émissions de gaz à effet de serre
 
+![icône heatmap](https://cdn.geotribu.fr/img/internal/icons-rdp-news/heatmap.png "icône heatmap"){: .img-rdp-news-thumb }
+
 Cédric Rossi (@cedricr) propose dans le carnet de recherches [Néocarto](https://neocarto.hypotheses.org), une série intéressante de [trois billets](https://neocarto.hypotheses.org/13482) portant sur la cartographie des émissions de gaz à effet de serre, en France et en Europe.
 
-Il partage également le .qpt du Template de sa carte [France entière avec les DROM à l'échelle](https://layout-hub.github.io/layout-dir/FranceDROM.qpt) sur le [hub QGIS](https://layout-hub.github.io/)
+[![Emissions de CO2](https://cdn.geotribu.fr/img/articles-blog-rdp/capture-ecran/carte_emissions_co2_2019_dorling.png "Emissions de CO2"){: .img-center loading=lazy }](https://cdn.geotribu.fr/img/articles-blog-rdp/capture-ecran/carte_emissions_co2_2019_dorling.png){: data-mediabox="lightbox-gallery" data-title="Cartogramme de Dorling des émissions de CO2 (2019) - Cédric ROSSI"}
 
+Il partage également le modèle de carte QGIS (format `.qpt`) [France entière avec les DROM à l'échelle](https://layout-hub.github.io/layout-dir/FranceDROM.qpt) sur le [hub QGIS](https://layout-hub.github.io/).
 
 ----
 


### PR DESCRIPTION
- Ajout complément d'informations sur info Cartographier les émissions de gaz a effet de serre

-> Ce serait bien de mettre l'une des cartes réalisées en illustration.
