### PR TITLE
Ajoute la gestion des licences pour les contenus

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 ![Pull Request Checker](https://github.com/geotribu/website/workflows/Pull%20Request%20Checker/badge.svg)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/geotribu/website/master.svg)](https://results.pre-commit.ci/latest/github/geotribu/website/master)
 
+[![Open in Visual Studio Code](https://open.vscode.dev/badges/open-in-vscode.svg)](https://open.vscode.dev/geotribu/website)
+
 Sources et contenus du site de Geotribu, accessible via les URLs suivantes :
 
 - <https://static.geotribu.fr>

--- a/content/articles/2021/2021-01-19_pyqgis_utiliser_icones_integrees.md
+++ b/content/articles/2021/2021-01-19_pyqgis_utiliser_icones_integrees.md
@@ -5,6 +5,7 @@ categories: ["article", "tutoriel"]
 date: "2021-01-19 14:20"
 description: "Pour le développement d'un plugin pour QGIS, soigner l'interface graphique peut être fastidieux, notamment de concevoir ou trouver les éléments graphiques. Pourquoi ne pas utiliser les icônes déjà embarquées dans QGIS ?."
 image: "https://cdn.geotribu.fr/img/tuto/qgis_plugin_embedded_images/qgis_icons_file-explorer.png"
+license: beerware
 tags: "QGIS,plugin,PyQt5,icônes,interface graphique"
 ---
 
@@ -78,9 +79,9 @@ Maintenant, vous n'avez plus aucune excuse pour ne pas mettre de belles icônes 
 
 ## Auteur
 
---8<--
-content/team/jmou.md
---8<--
+--8<-- content/team/jmou.md
+
+{% include "licenses/beerware.md" %}
 
 <!-- Hyperlinks reference -->
 [Oslandia]: https://oslandia.com/

--- a/content/articles/2021/2021-04-01_qtribu_plugin_qgis_geotribu.md
+++ b/content/articles/2021/2021-04-01_qtribu_plugin_qgis_geotribu.md
@@ -5,6 +5,7 @@ categories: ["article"]
 date: "2021-04-01 13:20"
 description: "Présentation du plugin de Geotribu pour QGIS : QTribu. Inutile donc forcément indispensable."
 image: "https://cdn.geotribu.fr/img/projets-geotribu/plugin_qtribu/qtribu_article_displayed.png"
+license: default
 tags: "QGIS,plugin,Geotribu,QTribu"
 ---
 
@@ -79,3 +80,5 @@ Une fois installé, le plugin s'intègre :
 ## Auteur
 
 --8<-- "content/team/jmou.md"
+
+{% include "licenses/default.md" %}

--- a/content/articles/2021/2021-06-11_qgis_personnaliser_splash_screen.md
+++ b/content/articles/2021/2021-06-11_qgis_personnaliser_splash_screen.md
@@ -5,6 +5,7 @@ categories: ["article", "tutoriel"]
 date: "2021-06-11 10:20"
 description: "Le lancement de QGIS vous semble long ? Vous êtes sur la LTR et las de voir la même image pendant 2 ans ? Voici comment personnaliser l'image au lancement de QGIS."
 image: "https://cdn.geotribu.fr/img/tuto/qgis_splash_screen/qgis_qtribu_splash_screen_custom.png"
+license: none
 tags: "QGIS,personnalisation,splash screen,démarrage"
 ---
 
@@ -107,3 +108,5 @@ Pas de souci, j'ai intégré la possibilité de le faire en un clic sur [notre p
 ## Auteur
 
 --8<-- "content/team/jmou.md"
+
+{% include "licenses/cc4_by-sa.md" %}

--- a/content/articles/2021/2021-07-06_qgis_personnaliser_package_osgeo4w.md
+++ b/content/articles/2021/2021-07-06_qgis_personnaliser_package_osgeo4w.md
@@ -318,3 +318,5 @@ Maintenant, à vous de jouer, et pensez à remonter toute anomalie ou améliorat
 ## Auteur
 
 --8<-- "content/team/rha.md"
+
+{% include "licenses/default.md" %}

--- a/content/articles/2021/2021-07-06_qgis_personnaliser_package_osgeo4w.md
+++ b/content/articles/2021/2021-07-06_qgis_personnaliser_package_osgeo4w.md
@@ -5,6 +5,7 @@ categories: ["article", "tutoriel"]
 date: "2021-07-06 10:20"
 description: "vous voulez contrôler l'interface et les paramètres de QGIS dans votre organisation. Ne pas infliger à vos utilisateurs de trifouiller les réglages du proxy, ou connaître l'adresse IP des serveurs PostGIS ? Suivez le guide pour industrialiser votre installation personnalisée de QGIS."
 image: "https://cdn.geotribu.fr/img/articles-blog-rdp/articles/qgis_customize_osgeo4w_rha/qgis_osgeo4w_voiture_rallye.png"
+license: default
 tags: "QGIS,personnalisation,osgeo4W,déploiement,configuration"
 ---
 
@@ -318,3 +319,5 @@ Maintenant, à vous de jouer, et pensez à remonter toute anomalie ou améliorat
 ## Auteur
 
 --8<-- "content/team/rha.md"
+
+{% include "licenses/default.md" %}

--- a/content/articles/2021/2021-07-06_qgis_personnaliser_package_osgeo4w.md
+++ b/content/articles/2021/2021-07-06_qgis_personnaliser_package_osgeo4w.md
@@ -318,5 +318,3 @@ Maintenant, à vous de jouer, et pensez à remonter toute anomalie ou améliorat
 ## Auteur
 
 --8<-- "content/team/rha.md"
-
-{% include "licenses/default.md" %}

--- a/content/articles/templates/template_article.md
+++ b/content/articles/templates/template_article.md
@@ -33,3 +33,5 @@ Texte.
 ## Auteur
 
 --8<-- "content/team/jmou.md"
+
+{% include "licenses/default.md" %}

--- a/content/contribuer/guides/.pages
+++ b/content/contribuer/guides/.pages
@@ -10,3 +10,4 @@ nav:
     - emoji.md
     - diagrams.md
     - authoring.md
+    - licensing.md

--- a/content/contribuer/guides/licensing.md
+++ b/content/contribuer/guides/licensing.md
@@ -9,33 +9,83 @@ tags: "contribuer,tutoriel,markdown,licence"
 
 # Choisir une licence pour son article
 
-> TO DOC
+![icône poignée de main](https://cdn.geotribu.fr/img/internal/icons-rdp-news/lobby.png "icône poignée de main"){: .img-rdp-news-thumb }
+
+En publiant un contenu sur un site public tel que Geotribu, il faut être conscient qu'il va potentiellement être copié, collé, modifié, entièrement ou partiellement, etc. La plupart du temps sans que l'auteur/e n'en soit notifié/e.  
+Même si cela n'empêchera pas les usages abusifs, il est recommandé de spécifier la licence du contenu, notamment pour dissiper le flou qui peut entourer la réutilisation du contenu.
+
+Geotribu applique une [licence par défaut](#licence-par-defaut) mais permet également à l'auteur/e de spécifier une licence spécifique sur ses articles.
 
 ## Licence par défaut
 
-Par défaut, la licence est celle-ci :
+Une licence par défaut a été choisie par [l'équipe](/team/). Sauf mention contraire, elle est automatiquement ajoutée dans le bas de page, entre les dates et les taux de contribution :
+
+![bandeau licence](https://cdn.geotribu.fr/img/internal/contribution/licensing/license_default.png "Bandeau licence bas de page")
+{: align=middle }
+
+----
+
+## Autres licences
+
+Chaque auteur/e peut également choisir d'indiquer une licence différente ou bien de mettre davantage en avant la licence par défaut en insérant un bloc plus complet directement dans le corps du contenu, généralement après le [le bloc auteur](/contribuer/guides/authoring/#bloc-auteur).
+
+### Syntaxe
+
+La syntaxe est celle de la [fonction d'intégration de Jinja](https://jinja.palletsprojects.com/en/latest/templates/#include). Pour appliquer la licence par défaut, il suffit d'insérer cette ligne :
+
+```markdown
+{% raw %}
+{% include "licenses/default.md" %}
+{% endraw %}
+```
+
+### Rendu
 
 {% include "licenses/default.md" %}
 
-## Licences disponibles
+### Licences disponibles
 
 | Nom et lien rendu | Commentaire | Syntaxe |
 | :------ | :---------- | :-----: |
-| [Creative Commons 4.0 BY-SA](/toc_nav_ignored/snippets/licenses/cc4_by-sa/) | Licence par défaut. | `\{% include "licenses/cc4_by-sa.md" %}``` |
-| [Creative Commons 4.0 BY-NC-SA](/toc_nav_ignored/snippets/licenses/cc4_by-nc-sa/) | Attention la clause de non utilisation commerciale est contestée, car considérée comme une entorse au principe de *Free Culture*. | `{% include "licenses/cc4_by-nc-sa.md" %}` |
+| [Creative Commons 4.0 BY-SA](/toc_nav_ignored/snippets/licenses/cc4_by-sa/) | Licence autorisant toutes les réutilisations, y compris pour une finalité commerciale. | {% raw %}`{% include "licenses/cc4_by-sa.md" %}`{% endraw %} |
+| [Creative Commons 4.0 BY-NC-SA](/toc_nav_ignored/snippets/licenses/cc4_by-nc-sa/) | **Licence par défaut**. Empêche la réutilisation pour une finalité commerciale. | {% raw %}`{% include "licenses/cc4_by-nc-sa.md" %}`{% endraw %} |
 
-La licence souhaitée n'est pas disponible ? Contactez-nous !
+!!! question "Suggérer une licence"
+    La licence souhaitée n'est pas disponible ? Proposez-la via GitHub en créant un fichier dans [ce dossier](https://github.com/geotribu/website/tree/master/content/toc_nav_ignored/snippets/licenses), ou [en ouvrant une issue](https://github.com/geotribu/website/issues/new?title=Ajout%20d%27une%20licence) et/ou contactez-nous !
 
-## Exemples
+----
+
+### Exemples
 
 Laisser la licence par défaut :
 
 ```markdown
-`{% include "licenses/default.md" %}`
+{% raw %}
+{% include "licenses/default.md" %}
+{% endraw %}
 ```
 
-Appliquer la licence CC 4.0 BY-NC-SA :
+Appliquer la licence CC 4.0 BY-SA :
 
 ```markdown
-`{% include "licenses/cc4_by-nc-sa.md" %}`
+{% raw %}
+{% include "licenses/cc4_by-sa.md" %}
+{% endraw %}
 ```
+
+----
+
+## Remarques
+
+### Prévalence du cadre légal
+
+Selon la casquelle avec laquelle vous rédigez un contenu, indiquer une licence contraire au cadre légal en vigueur ne suffira pas. Par exemple, si vous rédigez un contenu en tant qu'agent de la fonction publique (sur votre temps de travail ou pour une mission en particulier), spécifier une licence empêchant une réutilisation commerciale n'aura aucun effet, la [Licence Ouverte 2.0] s'appliquant de fait.
+
+### Sous le capot
+
+D'un point de vue technique, la gestion des licences est liée aux capacités de personnalisation du thème [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/customization/), du [plugin Macros](https://mkdocs-macros-plugin.readthedocs.io/en/latest/) qui tire parti de la [fonction d'intégration de Jinja](https://jinja.palletsprojects.com/en/latest/templates/#include).
+
+<!-- Hyperlinks reference -->
+[Licence Ouverte 2.0]: https://www.etalab.gouv.fr/wp-content/uploads/2017/04/ETALAB-Licence-Ouverte-v2.0.pdf
+
+<!-- Footnotes reference -->

--- a/content/contribuer/guides/licensing.md
+++ b/content/contribuer/guides/licensing.md
@@ -1,0 +1,41 @@
+---
+title: "Choisir une licence pour son article"
+categories: ["article", "contribution", "tutoriel"]
+date: "2021-07-12 11:20"
+description: "Comment choisir et appliquer une licence à son article Geotribu."
+image: "https://cdn.geotribu.fr/img/internal/contribution/markdown/markdown_yaml_frontmatter.png"
+tags: "contribuer,tutoriel,markdown,licence,droits"
+---
+
+# Choisir une licence pour son article
+
+> TO DOC
+
+## Licence par défaut
+
+Par défaut, la licence est celle-ci :
+
+{% include "licenses/default.md" %}
+
+## Licences disponibles
+
+| Licence | Commentaire | Syntaxe |
+| :------ | :---------- | :-----: |
+| Creative Commons 4.0 BY-SA | Licence par défaut. | `{% include "licenses/cc4_by-sa.md" %}` |
+| Creative Commons 4.0 BY-NC-SA | Attention la clause de non utilisation commerciale est contestée. | `{% include "licenses/cc4_by-nc-sa.md" %}` |
+
+La licence souhaitée n'est pas disponible ? Contactez-nous !
+
+## Exemples
+
+Laisser la licence par défaut :
+
+```markdown
+`{% include "licenses/default.md" %}`
+```
+
+Appliquer la licence CC 4.0 BY-NC-SA :
+
+```markdown
+`{% include "licenses/cc4_by-nc-sa.md" %}`
+```

--- a/content/contribuer/guides/licensing.md
+++ b/content/contribuer/guides/licensing.md
@@ -1,5 +1,5 @@
 ---
-title: "Choisir une licence pour son article"
+title: "Choisir une licence"
 categories: ["article", "contribution", "tutoriel"]
 date: "2021-07-12 11:20"
 description: "Comment choisir et appliquer une licence à son article Geotribu."
@@ -21,7 +21,7 @@ Par défaut, la licence est celle-ci :
 
 | Nom et lien rendu | Commentaire | Syntaxe |
 | :------ | :---------- | :-----: |
-| [Creative Commons 4.0 BY-SA](/toc_nav_ignored/snippets/licenses/cc4_by-sa/) | Licence par défaut. | `{% include "licenses/cc4_by-sa.md" %}` |
+| [Creative Commons 4.0 BY-SA](/toc_nav_ignored/snippets/licenses/cc4_by-sa/) | Licence par défaut. | `\{% include "licenses/cc4_by-sa.md" %}``` |
 | [Creative Commons 4.0 BY-NC-SA](/toc_nav_ignored/snippets/licenses/cc4_by-nc-sa/) | Attention la clause de non utilisation commerciale est contestée, car considérée comme une entorse au principe de *Free Culture*. | `{% include "licenses/cc4_by-nc-sa.md" %}` |
 
 La licence souhaitée n'est pas disponible ? Contactez-nous !

--- a/content/contribuer/guides/licensing.md
+++ b/content/contribuer/guides/licensing.md
@@ -3,7 +3,7 @@ title: "Choisir une licence"
 categories: ["article", "contribution", "tutoriel"]
 date: "2021-07-12 11:20"
 description: "Comment choisir et appliquer une licence à son article Geotribu."
-image: "https://cdn.geotribu.fr/img/internal/contribution/markdown/markdown_yaml_frontmatter.png"
+image: "https://cdn.geotribu.fr/img/internal/contribution/licensing/license_block.png"
 tags: "contribuer,tutoriel,markdown,licence"
 ---
 

--- a/content/contribuer/guides/licensing.md
+++ b/content/contribuer/guides/licensing.md
@@ -4,7 +4,7 @@ categories: ["article", "contribution", "tutoriel"]
 date: "2021-07-12 11:20"
 description: "Comment choisir et appliquer une licence à son article Geotribu."
 image: "https://cdn.geotribu.fr/img/internal/contribution/markdown/markdown_yaml_frontmatter.png"
-tags: "contribuer,tutoriel,markdown,licence,droits"
+tags: "contribuer,tutoriel,markdown,licence"
 ---
 
 # Choisir une licence pour son article
@@ -19,10 +19,10 @@ Par défaut, la licence est celle-ci :
 
 ## Licences disponibles
 
-| Licence | Commentaire | Syntaxe |
+| Nom et lien rendu | Commentaire | Syntaxe |
 | :------ | :---------- | :-----: |
-| Creative Commons 4.0 BY-SA | Licence par défaut. | `{% include "licenses/cc4_by-sa.md" %}` |
-| Creative Commons 4.0 BY-NC-SA | Attention la clause de non utilisation commerciale est contestée. | `{% include "licenses/cc4_by-nc-sa.md" %}` |
+| [Creative Commons 4.0 BY-SA](/toc_nav_ignored/snippets/licenses/cc4_by-sa/) | Licence par défaut. | `{% include "licenses/cc4_by-sa.md" %}` |
+| [Creative Commons 4.0 BY-NC-SA](/toc_nav_ignored/snippets/licenses/cc4_by-nc-sa/) | Attention la clause de non utilisation commerciale est contestée, car considérée comme une entorse au principe de *Free Culture*. | `{% include "licenses/cc4_by-nc-sa.md" %}` |
 
 La licence souhaitée n'est pas disponible ? Contactez-nous !
 

--- a/content/contribuer/guides/licensing.md
+++ b/content/contribuer/guides/licensing.md
@@ -60,6 +60,7 @@ La syntaxe est celle de la [fonction d'intégration de Jinja](https://jinja.pall
 | :------ | :---------- | :-----: |
 | [Creative Commons 4.0 BY-SA](/toc_nav_ignored/snippets/licenses/cc4_by-sa/) | Licence autorisant toutes les réutilisations, y compris pour une finalité commerciale. | {% raw %}`{% include "licenses/cc4_by-sa.md" %}`{% endraw %} |
 | [Creative Commons 4.0 BY-NC-SA](/toc_nav_ignored/snippets/licenses/cc4_by-nc-sa/) | **Licence par défaut**. Empêche la réutilisation pour une finalité commerciale. | {% raw %}`{% include "licenses/cc4_by-nc-sa.md" %}`{% endraw %} |
+| [Beerware](/toc_nav_ignored/snippets/licenses/beerware/) | Licence humoristique autorisant toute réutilisation sans conditions mais qui invite à payer un coup à l'auteur/e original/e. | {% raw %}`{% include "licenses/beerware.md" %}`{% endraw %} |
 
 !!! question "Suggérer une licence"
     La licence souhaitée n'est pas disponible ? Proposez-la via GitHub en créant un fichier dans [ce dossier](https://github.com/geotribu/website/tree/master/content/toc_nav_ignored/snippets/licenses), ou [en ouvrant une issue](https://github.com/geotribu/website/issues/new?title=Ajout%20d%27une%20licence) et/ou contactez-nous !

--- a/content/contribuer/guides/licensing.md
+++ b/content/contribuer/guides/licensing.md
@@ -18,18 +18,29 @@ Geotribu applique une [licence par défaut](#licence-par-defaut) mais permet ég
 
 ## Licence par défaut
 
-Une licence par défaut a été choisie par [l'équipe](/team/). Sauf mention contraire, elle est automatiquement ajoutée dans le bas de page, entre les dates et les taux de contribution :
+Une licence par défaut a été choisie par [l'équipe](/team/). Sauf mention contraire, elle est automatiquement ajoutée dans le bas de page :
 
 ![bandeau licence](https://cdn.geotribu.fr/img/internal/contribution/licensing/license_default.png "Bandeau licence bas de page")
 {: align=middle }
 
 ----
 
-## Autres licences
+## Choisir une autre licence
 
 Chaque auteur/e peut également choisir d'indiquer une licence différente ou bien de mettre davantage en avant la licence par défaut en insérant un bloc plus complet directement dans le corps du contenu, généralement après le [le bloc auteur](/contribuer/guides/authoring/#bloc-auteur).
 
 ### Syntaxe
+
+#### Désactiver la licence par défaut
+
+Cette étape n'est utile que si vous souhaitez utiliser une licence différente de celle par défaut.  
+Il suffit de modifier [l'en-tête de la page](/contribuer/guides/metadata_yaml_frontmatter/) ainsi :
+
+```yaml
+license: none
+```
+
+#### Insérer le bloc
 
 La syntaxe est celle de la [fonction d'intégration de Jinja](https://jinja.palletsprojects.com/en/latest/templates/#include). Pour appliquer la licence par défaut, il suffit d'insérer cette ligne :
 

--- a/content/contribuer/guides/markdown_basics.md
+++ b/content/contribuer/guides/markdown_basics.md
@@ -24,7 +24,6 @@ Le _[markdown]_ est une syntaxe extensible et son rendu dépend de l'outil utili
 C'est ce dernier qui fait foi.
 
 !!! tip
-
     Pour comprendre comment fonctionne le rendu des contenus, consulter [l'article dédié](/contribuer/build_site/markdown_engine/).
 
 #### Bien démarrer
@@ -54,7 +53,6 @@ N'importe quel éditeur de texte "plat" suffit pour rédiger en [Markdown].
 - [Upmath]
 
 !!! tip
-
     Le choix du Markdown pour Geotribu a été détaillé dans l'article [Du HTML au Markdown (et vice-versa)](/articles/2020/2020-09-11_html2markdown/). Il contient quelques éléments de compréhension sur la syntaxe et un petit TP pour s'exercer.
 
 [Prochaine étape : respecter et valider la syntaxe :fontawesome-solid-step-forward:](/contribuer/guides/markdown_quality/){: .md-button }
@@ -68,6 +66,7 @@ En plus des ressources, à suivre quelques exemples de base.
 
 ### Titres et paragraphes
 
+<!-- markdownlint-disable MD046 -->
 === "Markdown"
 
     ```markdown
@@ -167,6 +166,7 @@ En plus des ressources, à suivre quelques exemples de base.
         + signe plus (\+)
     * mais, pour éviter les effets de bord (espacement de paragraphe, mauvais niveau de retrait...) et selon les règles établies, il est préférable de rester cohérent dans le caractère utilisé, au moins dans un même document
     * en général, on utilise l'astérisque ou alors le tiret.
+<!-- markdownlint-enable MD046 -->
 
 [Prochaine étape : respecter et valider la syntaxe :fontawesome-solid-step-forward:](/contribuer/guides/markdown_quality/){: .md-button }
 {: align=middle }

--- a/content/contribuer/guides/metadata_yaml_frontmatter.md
+++ b/content/contribuer/guides/metadata_yaml_frontmatter.md
@@ -23,6 +23,7 @@ L'en-tête est défini en haut de la page par un ensemble de clés/valeurs encad
 - `date` : date de création publique de l'article, correspondant à la date de première publication. Utilisée dans le RSS, le SEO et certains moteurs d'affichage.
 - `description` : SEO, recherche interne du site, meta-tag, RSS
 - `image` : RSS et partage des articles dans les réseaux sociaux (c'est ce qui fait qu'on a un jouli rendu quand on partage dans Twitter ou LinkedIn par exemple). Dimensions : entre 300x600 et 400x800.
+- `license` : détermine si la licence du contenu est celle par défaut (`license: default`) ou non (`license: none`). Si la clé n'est pas renseignée, c'est la licence par défaut qui s'applique. Voir le guide [Choisir sa licence](/contribuer/guides/licensing/).
 - `tags` : pour l'instant ça ne sert à rien mais c'est prévu pour permettre un classement des contenus par mots-clés.
 
 ### Catégories
@@ -47,6 +48,7 @@ categories: ["revue de presse"]
 date: 2020-12-25 14:20
 description: "GeoRDP du 25 décembre 2020 : la revue de presse géomatique de Geotribu pour souhaiter Joyeux Noël et bonnes fêtes !"
 image: "https://cdn.geotribu.fr/img/articles-blog-rdp/merry_christmas_blender.png"
+license: default
 tags: rdp,ign,geoserver,nominatim,opendata,cerema,fig,georezo,drone,postgis,mapbox,openlayers
 ---
 ```

--- a/content/theme/assets/stylesheets/extra.css
+++ b/content/theme/assets/stylesheets/extra.css
@@ -2,100 +2,108 @@
 /* attribute classes to be used via {: .class} */
 
 img {
-    border-style: solid;
-    border-color: darkgrey;
-    border-width: thin;
-    box-shadow: 0px 1px 2px darkgrey;
+  border-style: solid;
+  border-color: darkgrey;
+  border-width: thin;
+  box-shadow: 0px 1px 2px darkgrey;
 }
 
 .img-rdp-news-thumb {
-    float: left;
-    clear: right;
-    overflow: auto;
-    margin-right: 10px;
-    max-height: 75px;
-    max-width: 75px;
-    box-shadow: none;
-    border: none;
+  float: left;
+  clear: right;
+  overflow: auto;
+  margin-right: 10px;
+  max-height: 75px;
+  max-width: 75px;
+  box-shadow: none;
+  border: none;
 }
 
-.emojione, .twemoji {
-    box-shadow: none;
-    border: none;
+.emojione,
+.twemoji {
+  box-shadow: none;
+  border: none;
 }
 
 .img-right {
-    /* right align with text float on the left */
-    float: right;
-    margin-left: 10px;
+  /* right align with text float on the left */
+  float: right;
+  margin-left: 10px;
 }
 
-
 .img-center {
-    display: block;
-    margin-left: auto;
-    margin-right: auto;
-    width: 75%;
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+  width: 75%;
+}
+
+.img-license-picto {
+  box-shadow: none;
+  border: none;
+  height: 22px !important;
+  margin-left: 3px;
+  vertical-align: text-bottom;
 }
 
 /* Copyleft */
 /* see: https://stackoverflow.com/questions/37088198/copyleft-symbol */
 
 .copyleft {
-    display: inline-block;
-    transform: rotate(180deg);
+  display: inline-block;
+  transform: rotate(180deg);
 }
-
 
 /* Custom buttons to set dark/ligth modes */
 
 .md-typeset button[data-md-color-scheme] {
-    cursor: pointer;
-    transition: opacity 250ms;
-    font-size: larger;
+  cursor: pointer;
+  transition: opacity 250ms;
+  font-size: larger;
 }
 
 .md-typeset button[data-md-color-scheme]:hover {
-    opacity: 0.75;
+  opacity: 0.75;
 }
 
-.md-typeset button[data-md-color-scheme]>code {
-    display: block;
-    color: var(--md-primary-bg-color);
-    background-color: var(--md-primary-fg-color);
+.md-typeset button[data-md-color-scheme] > code {
+  display: block;
+  color: var(--md-primary-bg-color);
+  background-color: var(--md-primary-fg-color);
 }
 
 /* Customize embedded tweets */
 
 blockquote.twitter-tweet {
-    display: inline-block;
-    font-family: "Helvetica Neue", Roboto, "Segoe UI", Calibri, sans-serif;
-    font-size: 12px;
-    font-weight: bold;
-    line-height: 16px;
-    border-color: #eee #ddd #bbb;
-    border-radius: 5px;
-    border-style: solid;
-    border-width: 1px;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
-    margin: 10px 5px;
-    padding: 0 16px 16px 16px;
-    max-width: 468px;
+  display: inline-block;
+  font-family: "Helvetica Neue", Roboto, "Segoe UI", Calibri, sans-serif;
+  font-size: 12px;
+  font-weight: bold;
+  line-height: 16px;
+  border-color: #eee #ddd #bbb;
+  border-radius: 5px;
+  border-style: solid;
+  border-width: 1px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+  margin: 10px 5px;
+  padding: 0 16px 16px 16px;
+  max-width: 468px;
 }
 
 blockquote.twitter-tweet p {
-    font-size: 16px;
-    font-weight: normal;
-    line-height: 20px;
+  font-size: 16px;
+  font-weight: normal;
+  line-height: 20px;
 }
 
 blockquote.twitter-tweet a {
-    color: inherit;
-    font-weight: normal;
-    text-decoration: none;
-    outline: 0 none;
+  color: inherit;
+  font-weight: normal;
+  text-decoration: none;
+  outline: 0 none;
 }
 
-blockquote.twitter-tweet a:hover, blockquote.twitter-tweet a:focus {
-    text-decoration: underline;
+blockquote.twitter-tweet a:hover,
+blockquote.twitter-tweet a:focus {
+  text-decoration: underline;
 }

--- a/content/theme/main.html
+++ b/content/theme/main.html
@@ -2,33 +2,33 @@
 
 {% block extrahead %}
   <meta property="robots" content="all" />
-  <!-- RSS Feed -->
+  {# RSS Feed #}
   <link rel="alternate" type="application/rss+xml" title="RSS feed of created content" href="{{ config.site_url }}feed_rss_created.xml">
   <link rel="alternate" type="application/rss+xml" title="RSS feed of updated content" href="{{ config.site_url }}feed_rss_updated.xml">
-  <!-- Meta title -->
+  {# Meta title #}
   {% set title = config.site_name %}
   {% if page and page.meta and page.meta.title %}
   {% set title = title ~ " - " ~ page.meta.title %}
   {% elif page and page.title and not page.is_homepage %}
   {% set title = title ~ " - " ~ page.title | striptags %}
   {% endif %}
-  <!-- Meta date -->
+  {# Meta date #}
   {% if page and page.meta and page.meta.date %}
   {% set date = page.meta.date %}
   {% endif %}
-  <!-- Meta description -->
+  {# Meta description #}
   {% set description = config.site_description %}
   {% if page and page.meta and page.meta.description %}
   {% set description = page.meta.description | striptags %}
   {% elif page and page.description and not page.is_homepage %}
   {% set description = page.description | striptags %}
   {% endif %}
-  <!-- Meta image -->
+  {# Meta image #}
   {% set image = 'https://cdn.geotribu.fr/img/internal/charte/geotribu_banner.jpg' %}
   {% if page and page.meta and page.meta.image %}
   {% set image = page.meta.image %}
   {% endif %}
-  <!-- Meta author -->
+  {# Meta author #}
   {% set author = config.site_author %}
   {% if page and page.meta and page.meta.authors and not page.is_homepage %}
   {% set author = page.meta.authors %}
@@ -46,21 +46,21 @@
   <meta name="author" content="{{ author }}">
   {% endif %}
 
-  <!-- Meta type -->
+  {# Meta type #}
   {% if page.is_homepage %}
   {% set type = "website" %}
   {% else %}
   {% set type = "article" %}
   {% endif %}
 
-  <!-- OpenGraph -->
+  {# OpenGraph #}
   <meta property="og:description" content="{{ description }}">
   <meta property="og:image" content="{{ image }}">
   <meta property="og:locale" content="fr_FR" />
   <meta property="og:title" content="{{ title }}">
   <meta property="og:type" content="{{ type }}">
   <meta property="og:url" content="{{ page.canonical_url }}">
-  <!-- Twitter -->
+  {# Twitter #}
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:creator" content="@geojulien" />
   <meta name="twitter:description" content="{{ description }}">
@@ -69,7 +69,7 @@
   <meta name="twitter:site" content="@geotribu" />
   <meta name="twitter:title" content="{{ title }}">
   <meta name="twitter:widgets:align" content="center">
-  <!-- Structured data using schema.org -->
+  {# Structured data using schema.org #}
   {% if type == "article" %}
     <script type="application/ld+json">
     {
@@ -97,7 +97,7 @@
 {% endblock %}
 
 {% block libs %}
-  <!-- Handle Twitter oEmbed - See #54 -->
+  {# Handle Twitter oEmbed - See #54 #}
   <script charset="utf-8" id="twitter-wjs" type="text/javascript" src="https://platform.twitter.com/widgets.js"></script>
 
 {% endblock %}

--- a/content/theme/main.html
+++ b/content/theme/main.html
@@ -104,6 +104,15 @@
 
 {% block disqus %}
 
+  {% if not page.is_homepage %}
+  {# Authoring based on git log #}
+    <div class="md-source-date">
+      <small>
+        Contributions à cette page : {{ git_page_authors }}
+      </small>
+    </div>
+  {% endif %}
+
   {# License #}
   {% if not page.is_homepage  and ("license" not in page.meta or page.meta.license == "default") %}
     <div class="md-source-date">
@@ -138,36 +147,29 @@
   {% endif %}
 
   {% if not page.is_homepage %}
-    {# Authoring based on git log #}
-    <div class="md-source-date">
-      <small>
-        Contributions à cette page : {{ git_page_authors }}
-      </small>
+  {# Comment system (Isso) #}
+    <div id="__comments">
+      <script
+        data-isso="{{ config.extra.comments_url }}/"
+        data-isso-feed="true"
+        data-isso-reply-notifications="true"
+        data-isso-reply-to-self="false"
+        data-isso-require-author="true"
+        data-isso-require-email="true"
+        data-isso-vote="true"
+        src="{{ config.extra.comments_url }}/js/embed.min.js">
+        </script>
+      <hr>
+      <section id="isso-thread">
+        <h2>Commentaires</h2>
+        <small>
+          Une version minimale de la <a href="/contribuer/guides/markdown_basics/" hreflang="fr" target="_blank">syntaxe
+            markdown</a> est
+          acceptée pour la mise en forme des commentaires.<br>Propulsé par <a href="https://posativ.org/isso/" hreflang="en" target="_blank">Isso</a>. </small>
+      </section>
+      <noscript>Please enable JavaScript to view the comments.</noscript>
     </div>
-
-{# Comment system (Isso) #}
-<div id="__comments">
-  <script
-    data-isso="{{ config.extra.comments_url }}/"
-    data-isso-feed="true"
-    data-isso-reply-notifications="true"
-    data-isso-reply-to-self="false"
-    data-isso-require-author="true"
-    data-isso-require-email="true"
-    data-isso-vote="true"
-    src="{{ config.extra.comments_url }}/js/embed.min.js">
-    </script>
-  <hr>
-  <section id="isso-thread">
-    <h2>Commentaires</h2>
-    <small>
-      Une version minimale de la <a href="/contribuer/guides/markdown_basics/" hreflang="fr" target="_blank">syntaxe
-        markdown</a> est
-      acceptée pour la mise en forme des commentaires.<br>Propulsé par <a href="https://posativ.org/isso/" hreflang="en" target="_blank">Isso</a>. </small>
-  </section>
-  <noscript>Please enable JavaScript to view the comments.</noscript>
-</div>
-{% endif %}
+  {% endif %}
 {% endblock %}
 
 {% block scripts %}

--- a/content/theme/main.html
+++ b/content/theme/main.html
@@ -104,6 +104,39 @@
 
 {% block disqus %}
 
+  {# License #}
+  {% if not page.is_homepage  and ("license" not in page.meta or page.meta.license == "default") %}
+    <div class="md-source-date">
+      <small>
+      <p xmlns:cc="http://creativecommons.org/ns#">
+        Ce contenu est sous licence Creative Commons
+        <a
+          href="https://creativecommons.org/licenses/by-nc-sa/4.0/deed.fr"
+          target="_blank"
+          rel="license noopener noreferrer"
+          >BY-NC-SA 4.0 International
+            <img
+            src="https://mirrors.creativecommons.org/presskit/icons/cc.svg"
+            class=img-license-picto
+            />
+          <img
+            src="https://mirrors.creativecommons.org/presskit/icons/by.svg"
+            class=img-license-picto
+            />
+          <img
+            src="https://mirrors.creativecommons.org/presskit/icons/nc.svg"
+            class=img-license-picto
+            />
+          <img
+            src="https://mirrors.creativecommons.org/presskit/icons/sa.svg"
+            class=img-license-picto
+            />
+        </a>
+      </p>
+      </small>
+    </div>
+  {% endif %}
+
   {% if not page.is_homepage %}
     {# Authoring based on git log #}
     <div class="md-source-date">
@@ -140,7 +173,6 @@
 {% block scripts %}
   {{ super() }}
   <script type="text/javascript">
-    // Translate - set before any binding
     WAMediaBox.lang = {
       prev: "Précédente",
       next: "Suivante",

--- a/content/toc_nav_ignored/snippets/licenses/beerware.md
+++ b/content/toc_nav_ignored/snippets/licenses/beerware.md
@@ -1,0 +1,18 @@
+<!-- markdownlint-disable MD026 MD041 -->
+## Licence Beerware :fontawesome-solid-beer: :fontawesome-solid-mug-hot: {: id="license" }
+
+Ce contenu est sous licence [Beerware (Révision 42)](https://fr.wikipedia.org/wiki/Beerware).  
+Les médias d'illustration sont potentiellement soumis à d'autres conditions d'utilisation.
+
+<!-- markdownlint-disable MD046 -->
+??? quote "Détails"
+    Tant que vous conservez cette licence :
+
+    * vous pouvez faire ce que vous voulez de ce contenu
+    * si vous rencontrez l'auteur/e un jour et que vous pensez que ce contenu vaut le coup, vous pouvez lui payer un coup en retour
+
+    Citer cet article :
+
+    > "*{{ page.title }}*" publié par {{ page.meta.authors | join(",") }} sur **{{ config.site_name }}** - Source : <{{ page.canonical_url }}>
+
+<!-- markdownlint-enable MD026 MD041 MD046 -->

--- a/content/toc_nav_ignored/snippets/licenses/cc4_by-nc-sa.md
+++ b/content/toc_nav_ignored/snippets/licenses/cc4_by-nc-sa.md
@@ -1,5 +1,5 @@
 <!-- markdownlint-disable MD026 MD041 -->
-## Licence :fontawesome-brands-creative-commons: :fontawesome-brands-creative-commons-by: :fontawesome-brands-creative-commons-nc-eu: :fontawesome-brands-creative-commons-sa:
+## Licence :fontawesome-brands-creative-commons: :fontawesome-brands-creative-commons-by: :fontawesome-brands-creative-commons-nc-eu: :fontawesome-brands-creative-commons-sa: {: id="license" }
 
 Ce contenu est sous licence [Creative Commons International 4.0 BY-NC-SA](https://creativecommons.org/licenses/by-nc-sa/4.0/deed.fr), avec attribution et partage dans les mêmes conditions, sauf dans le cadre d'une utilisation commerciale.  
 Les médias d'illustration sont potentiellement soumis à d'autres conditions d'utilisation.
@@ -13,6 +13,6 @@ Les médias d'illustration sont potentiellement soumis à d'autres conditions d'
 
     Citer cet article :
 
-    > "*{{ page.title }}*" publié par {{ page.meta.authors | join(",") }} sur **{{ config.site_name }}** - Source : <{{ page.canonical_url }}>
+    > "*{{ page.title }}*" publié par {{ page.meta.authors | join(",") }} sur **{{ config.site_name }}** sous [CC BY-NC-SA](https://creativecommons.org/licenses/by-nc-sa/4.0/deed.fr) - Source : <{{ page.canonical_url }}>
 
 <!-- markdownlint-enable MD026 MD041 MD046 -->

--- a/content/toc_nav_ignored/snippets/licenses/cc4_by-nc-sa.md
+++ b/content/toc_nav_ignored/snippets/licenses/cc4_by-nc-sa.md
@@ -1,0 +1,18 @@
+<!-- markdownlint-disable MD026 MD041 -->
+## Licence :fontawesome-brands-creative-commons: :fontawesome-brands-creative-commons-by: :fontawesome-brands-creative-commons-nc-eu: :fontawesome-brands-creative-commons-sa:
+
+Ce contenu est sous licence [Creative Commons International 4.0 BY-NC-SA](https://creativecommons.org/licenses/by-nc-sa/4.0/deed.fr), avec attribution et partage dans les mêmes conditions, sauf dans le cadre d'une utilisation commerciale.  
+Les médias d'illustration sont potentiellement soumis à d'autres conditions d'utilisation.
+
+<!-- markdownlint-disable MD046 -->
+??? quote "Détails"
+    Vous êtes autorisé(e) à :
+
+    - **Partager** : copier, distribuer et communiquer le matériel par tous moyens et sous tous formats
+    - **Adapter** : remixer, transformer et créer à partir du matériel pour toute utilisation, exceptée commerciale.
+
+    Citer cet article :
+
+    > "*{{ page.title }}*" publié par {{ page.meta.authors | join(",") }} sur **{{ config.site_name }}** - Source : <{{ page.canonical_url }}>
+
+<!-- markdownlint-enable MD026 MD041 MD046 -->

--- a/content/toc_nav_ignored/snippets/licenses/cc4_by-sa.md
+++ b/content/toc_nav_ignored/snippets/licenses/cc4_by-sa.md
@@ -1,5 +1,5 @@
 <!-- markdownlint-disable MD026 MD041 -->
-## Licence :fontawesome-brands-creative-commons: :fontawesome-brands-creative-commons-by: :fontawesome-brands-creative-commons-sa:
+## Licence :fontawesome-brands-creative-commons: :fontawesome-brands-creative-commons-by: :fontawesome-brands-creative-commons-sa: {: id="license" }
 
 Ce contenu est sous licence [Creative Commons International 4.0 BY-SA](https://creativecommons.org/licenses/by-sa/4.0/deed.fr), avec attribution et partage dans les mêmes conditions.  
 Les médias d'illustration sont potentiellement soumis à d'autres conditions d'utilisation.

--- a/content/toc_nav_ignored/snippets/licenses/cc4_by-sa.md
+++ b/content/toc_nav_ignored/snippets/licenses/cc4_by-sa.md
@@ -1,0 +1,18 @@
+<!-- markdownlint-disable MD026 MD041 -->
+## Licence :fontawesome-brands-creative-commons: :fontawesome-brands-creative-commons-by: :fontawesome-brands-creative-commons-sa:
+
+Ce contenu est sous licence [Creative Commons International 4.0 BY-SA](https://creativecommons.org/licenses/by-sa/4.0/deed.fr), avec attribution et partage dans les mêmes conditions.  
+Les médias d'illustration sont potentiellement soumis à d'autres conditions d'utilisation.
+
+<!-- markdownlint-disable MD046 -->
+??? quote "Détails"
+    Vous êtes autorisé(e) à :
+
+    - **Partager** : copier, distribuer et communiquer le matériel par tous moyens et sous tous formats
+    - **Adapter** : remixer, transformer et créer à partir du matériel pour toute utilisation, y compris commerciale.
+
+    Citer cet article :
+
+    > "*{{ page.title }}*" publié par {{ page.meta.authors | join(",") }} sur **{{ config.site_name }}** - Source : <{{ page.canonical_url }}>
+
+<!-- markdownlint-enable MD026 MD041 MD046 -->

--- a/content/toc_nav_ignored/snippets/licenses/default.md
+++ b/content/toc_nav_ignored/snippets/licenses/default.md
@@ -1,0 +1,2 @@
+<!-- markdownlint-disable -->
+{% include "licenses/cc4_by-sa.md" %}

--- a/content/toc_nav_ignored/snippets/licenses/default.md
+++ b/content/toc_nav_ignored/snippets/licenses/default.md
@@ -1,2 +1,2 @@
 <!-- markdownlint-disable -->
-{% include "licenses/cc4_by-sa.md" %}
+{% include "licenses/cc4_by-nc-sa.md" %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ plugins:
   - git-authors:
       show_contribution: true
   - git-revision-date-localized:
+      enable_creation_date: true
       fallback_to_build_date: true
   - minify:
       minify_html: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,8 @@ plugins:
       lang: fr
       prebuild_index: !!python/object/apply:os.getenv ["MKDOCS_SEARCH_PREBUILD_INDEX"]
       separator: '[\s\-\.]+'
+  - macros:
+      include_dir: content/toc_nav_ignored/snippets
   - redirects:
       redirect_maps:
         # RSS

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ mkdocs-awesome-pages-plugin>=2.4,<2.6
 mkdocs-exclude>=1.0,<1.1
 mkdocs-git-authors-plugin==0.3.*
 mkdocs-git-revision-date-localized-plugin>=0.9,<0.10
+mkdocs-macros-plugin>=0.5,<0.6
 mkdocs-material>=7.1,<7.2
 mkdocs-minify-plugin==0.4.*
 mkdocs-redirects==1.0.*


### PR DESCRIPTION
L'objectif est résumé dans #344. Dans le détail :

- ajout d'un mécanisme (via macro plugin) d'intégration automatisée d'une licence dans un article
- ajout d'un mécanisme de licence par défaut
- ajout de quelques licences pour commencer : CC BY-SA, CC BY-NC-SA et Beerware

Close #344