### PR TITLE
Bump Material to 7.2+

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,6 +98,9 @@ theme:
     - navigation.expand
     - navigation.tabs
     - navigation.top
+    - search.highlight
+    - search.share
+    - search.suggest
   font: false
   icon:
     repo: fontawesome/brands/github-alt

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ mkdocs-exclude>=1.0,<1.1
 mkdocs-git-authors-plugin==0.3.*
 mkdocs-git-revision-date-localized-plugin>=0.9,<0.10
 mkdocs-macros-plugin>=0.5,<0.6
-mkdocs-material>=7.1,<7.2
+mkdocs-material>=7.1,<7.3
 mkdocs-minify-plugin==0.4.*
 mkdocs-redirects==1.0.*
 mkdocs-rss-plugin>=0.16,<0.18


### PR DESCRIPTION
Dernière version du thème et activation des fonctionnalités ouvertes grâce au modèle Sponsorware :

Voir https://squidfunk.github.io/mkdocs-material/changelog/#720-_-july-21-2021