### PR TITLE
Fonctionnalité: taxonomie

### DIFF
--- a/content/articles/2008/art_2008-11-03.md
+++ b/content/articles/2008/art_2008-11-03.md
@@ -5,6 +5,7 @@ categories: ["article"]
 date: 2008-11-03
 description: "Lancement du blog de Geotribu"
 tags:
+  - unknown
 ---
 
 # Premiers pas dans la cour des grands

--- a/content/articles/2009/art_2009-01-21.md
+++ b/content/articles/2009/art_2009-01-21.md
@@ -4,6 +4,7 @@ authors: GeoTribu
 categories: ["article"]
 date: 2009-01-21
 tags:
+  - unknown
 ---
 
 # Liste des logiciels OpenSource disponibles

--- a/content/articles/2009/art_2009-01-26.md
+++ b/content/articles/2009/art_2009-01-26.md
@@ -4,6 +4,7 @@ authors: GeoTribu
 categories: ["article"]
 date: 2009-01-26
 tags:
+  - unknown
 ---
 
 # Interview de David Jonglez, co-fondateur de Camptocamp

--- a/content/articles/2009/art_2009-02-01.md
+++ b/content/articles/2009/art_2009-02-01.md
@@ -4,6 +4,7 @@ authors: GeoTribu
 categories: ["article"]
 date: 2009-02-01
 tags:
+  - unknown
 ---
 
 # Les plus grands mensonges à l'encontre de l'openSource

--- a/content/articles/2009/art_2009-03-03.md
+++ b/content/articles/2009/art_2009-03-03.md
@@ -4,6 +4,7 @@ authors: GeoTribu
 categories: ["article"]
 date: 2009-03-03
 tags:
+  - unknown
 ---
 
 # GéoDjango LE framework cartographique de haut niveau

--- a/content/articles/2009/art_2009-03-05.md
+++ b/content/articles/2009/art_2009-03-05.md
@@ -4,6 +4,7 @@ authors: GeoTribu
 categories: ["article"]
 date: 2009-03-05
 tags:
+  - unknown
 ---
 
 # Cartogaphier l'immatériel

--- a/content/articles/2009/art_2009-03-18.md
+++ b/content/articles/2009/art_2009-03-18.md
@@ -4,6 +4,7 @@ authors: GeoTribu
 categories: ["article"]
 date: 2009-03-18
 tags:
+  - unknown
 ---
 
 # Explorer le format GeoRSS

--- a/content/articles/2009/art_2009-03-26.md
+++ b/content/articles/2009/art_2009-03-26.md
@@ -4,6 +4,7 @@ authors: GeoTribu
 categories: ["article"]
 date: 2009-03-26
 tags:
+  - unknown
 ---
 
 # Toulouse bientôt ville numérique ?

--- a/content/articles/2009/art_2009-03-31.md
+++ b/content/articles/2009/art_2009-03-31.md
@@ -4,6 +4,7 @@ authors: GeoTribu
 categories: ["article"]
 date: 2009-03-31
 tags:
+  - unknown
 ---
 
 # Enfin une émission de qualité à la télévision !

--- a/content/articles/2009/art_2009-04-01.md
+++ b/content/articles/2009/art_2009-04-01.md
@@ -4,6 +4,7 @@ authors: GeoTribu
 categories: ["article"]
 date: 2009-04-01
 tags:
+  - unknown
 ---
 
 # Coup de flippe et réflexion sur l'API Google Maps

--- a/content/rdp/2015/rdp_2015-03-06.md
+++ b/content/rdp/2015/rdp_2015-03-06.md
@@ -5,6 +5,7 @@ categories: ["revue de presse"]
 date: 2015-03-06
 description: "Revue de presse du 6 Mars"
 tags:
+  - unknown
 ---
 
 # Revue de presse du 6 Mars 2015

--- a/content/rdp/2015/rdp_2015-03-13.md
+++ b/content/rdp/2015/rdp_2015-03-13.md
@@ -5,6 +5,7 @@ categories: ["revue de presse"]
 date: 2015-03-13
 description: "Revue de presse du 13 Mars"
 tags:
+  - unknown
 ---
 
 # Revue de presse du 13 Mars 2015

--- a/content/rdp/2015/rdp_2015-03-16.md
+++ b/content/rdp/2015/rdp_2015-03-16.md
@@ -5,6 +5,7 @@ categories: ["revue de presse"]
 date: 2015-03-16
 description: "Revue de presse du 20 mars"
 tags:
+  - unknown
 ---
 
 # Revue de presse du 20 mars 2015

--- a/content/rdp/2015/rdp_2015-03-27.md
+++ b/content/rdp/2015/rdp_2015-03-27.md
@@ -5,6 +5,7 @@ categories: ["revue de presse"]
 date: 2015-03-27
 description: "Revue de presse du 27 mars"
 tags:
+  - unknown
 ---
 
 # Revue de presse du 27 mars 2015

--- a/content/rdp/2015/rdp_2015-04-07.md
+++ b/content/rdp/2015/rdp_2015-04-07.md
@@ -5,6 +5,7 @@ categories: ["revue de presse"]
 date: 2015-04-07
 description: "Revue de presse du 7 avril"
 tags:
+  - unknown
 ---
 
 # Revue de presse du 7 avril 2015

--- a/content/rdp/2015/rdp_2015-04-10.md
+++ b/content/rdp/2015/rdp_2015-04-10.md
@@ -5,6 +5,7 @@ categories: ["revue de presse"]
 date: 2015-04-10
 description: "Revue de presse du 10 Avril"
 tags:
+  - unknown
 ---
 
 # Revue de presse du 10 Avril 2015

--- a/content/rdp/2015/rdp_2015-04-20.md
+++ b/content/rdp/2015/rdp_2015-04-20.md
@@ -5,6 +5,7 @@ categories: ["revue de presse"]
 date: 2015-04-20
 description: "Revue de presse du 17 avril"
 tags:
+  - unknown
 ---
 
 # Revue de presse du 17 avril 2015

--- a/content/rdp/2015/rdp_2015-04-24.md
+++ b/content/rdp/2015/rdp_2015-04-24.md
@@ -5,6 +5,7 @@ categories: ["revue de presse"]
 date: 2015-04-24
 description: "Revue de presse du 24 avril"
 tags:
+  - unknown
 ---
 
 # Revue de presse du 24 avril 2015

--- a/content/rdp/2015/rdp_2015-05-01.md
+++ b/content/rdp/2015/rdp_2015-05-01.md
@@ -5,6 +5,7 @@ categories: ["revue de presse"]
 date: 2015-05-01
 description: "Revue de presse du 1 Mai"
 tags:
+  - unknown
 ---
 
 # Revue de presse du 1 Mai 2015

--- a/content/rdp/2015/rdp_2015-05-16.md
+++ b/content/rdp/2015/rdp_2015-05-16.md
@@ -5,6 +5,7 @@ categories: ["revue de presse"]
 date: 2015-05-16
 description: "Revue de presse du 15 mai"
 tags:
+  - unknown
 ---
 
 # Revue de presse du 15 mai 2015

--- a/content/rdp/2015/rdp_2015-05-29.md
+++ b/content/rdp/2015/rdp_2015-05-29.md
@@ -5,6 +5,7 @@ categories: ["revue de presse"]
 date: 2015-05-29
 description: "Revue de presse du 29 mai"
 tags:
+  - unknown
 ---
 
 # Revue de presse du 29 mai 2015

--- a/content/rdp/2015/rdp_2015-06-05.md
+++ b/content/rdp/2015/rdp_2015-06-05.md
@@ -5,6 +5,7 @@ categories: ["revue de presse"]
 date: 2015-06-05
 description: "Revue de presse de la semaine du 5 juin 2015"
 tags:
+  - unknown
 ---
 
 # Revue de presse du 5 juin 2015

--- a/content/rdp/2015/rdp_2015-06-12.md
+++ b/content/rdp/2015/rdp_2015-06-12.md
@@ -5,6 +5,7 @@ categories: ["revue de presse"]
 date: 2015-06-12
 description: "Revue de presse du 12 Juin"
 tags:
+  - unknown
 ---
 
 # Revue de presse du 12 Juin 2015

--- a/content/rdp/2015/rdp_2015-06-19.md
+++ b/content/rdp/2015/rdp_2015-06-19.md
@@ -5,6 +5,7 @@ categories: ["revue de presse"]
 date: 2015-06-19
 description: "Revue de presse du 19 juin"
 tags:
+  - unknown
 ---
 
 # Revue de presse du 19 juin 2015

--- a/content/rdp/2015/rdp_2015-07-03.md
+++ b/content/rdp/2015/rdp_2015-07-03.md
@@ -5,6 +5,7 @@ categories: ["revue de presse"]
 date: 2015-07-03
 description: "Revue de presse du 3 Juillet"
 tags:
+  - unknown
 ---
 
 # Revue de presse du 3 Juillet 2015

--- a/content/rdp/2015/rdp_2015-07-17.md
+++ b/content/rdp/2015/rdp_2015-07-17.md
@@ -5,6 +5,7 @@ categories: ["revue de presse"]
 date: 2015-07-17
 description: "Revue de presse du 17 juillet"
 tags:
+  - unknown
 ---
 
 # Revue de presse du 17 juillet 2015

--- a/content/rdp/2015/rdp_2015-09-01.md
+++ b/content/rdp/2015/rdp_2015-09-01.md
@@ -5,6 +5,7 @@ categories: ["revue de presse"]
 date: 2015-09-01
 description: "Revue de presse du... retour des vacances"
 tags:
+  - unknown
 ---
 
 # Revue de presse du... retour des vacances 2015

--- a/content/rdp/2015/rdp_2015-09-18.md
+++ b/content/rdp/2015/rdp_2015-09-18.md
@@ -5,6 +5,7 @@ categories: ["revue de presse"]
 date: 2015-09-18
 description: "Revue de presse du 18 septembre"
 tags:
+  - unknown
 ---
 
 # Revue de presse du 18 septembre 2015

--- a/content/rdp/2015/rdp_2015-09-21.md
+++ b/content/rdp/2015/rdp_2015-09-21.md
@@ -5,6 +5,7 @@ categories: ["revue de presse"]
 date: 2015-09-21
 description: "Revue de presse du 25 Septembre"
 tags:
+  - unknown
 ---
 
 # Revue de presse du 25 Septembre 2015

--- a/content/rdp/2015/rdp_2015-10-02.md
+++ b/content/rdp/2015/rdp_2015-10-02.md
@@ -5,6 +5,7 @@ categories: ["revue de presse"]
 date: 2015-10-02
 description: "Revue de presse du 2 Octobre"
 tags:
+  - unknown
 ---
 
 # Revue de presse du 2 Octobre 2015

--- a/content/rdp/2015/rdp_2015-10-16.md
+++ b/content/rdp/2015/rdp_2015-10-16.md
@@ -5,6 +5,7 @@ categories: ["revue de presse"]
 date: 2015-10-16
 description: "Revue de presse du 16 Octobre 2015"
 tags:
+  - unknown
 ---
 
 # Revue de presse du 16 Octobre 2015

--- a/content/rdp/2015/rdp_2015-11-13.md
+++ b/content/rdp/2015/rdp_2015-11-13.md
@@ -5,6 +5,7 @@ categories: ["revue de presse"]
 date: 2015-11-13
 description: "Revue de presse du 13 Novembre"
 tags:
+  - unknown
 ---
 
 # Revue de presse du 13 Novembre 2015

--- a/content/rdp/2015/rdp_2015-11-30.md
+++ b/content/rdp/2015/rdp_2015-11-30.md
@@ -5,6 +5,7 @@ categories: ["revue de presse"]
 date: 2015-11-30
 description: "Revue de presse du 11 décembre"
 tags:
+  - unknown
 ---
 
 # Revue de presse du 11 décembre 2015

--- a/content/rdp/2015/rdp_2015-12-21.md
+++ b/content/rdp/2015/rdp_2015-12-21.md
@@ -5,6 +5,7 @@ categories: ["revue de presse"]
 date: 2015-12-21
 description: "Revue de presse du 18 décembre"
 tags:
+  - unknown
 ---
 
 # Revue de presse du 18 décembre 2015

--- a/content/rdp/2016/rdp_2016-01-15.md
+++ b/content/rdp/2016/rdp_2016-01-15.md
@@ -5,6 +5,7 @@ categories: ["revue de presse"]
 date: 2016-01-15
 description: "Revue de presse du 15 janvier"
 tags:
+  - unknown
 ---
 
 # Revue de presse du 15 janvier 2016

--- a/content/rdp/2016/rdp_2016-02-05.md
+++ b/content/rdp/2016/rdp_2016-02-05.md
@@ -5,6 +5,7 @@ categories: ["revue de presse"]
 date: 2016-02-05
 description: "Revue de presse du 5 Février"
 tags:
+  - unknown
 ---
 
 # Revue de presse du 5 Février 2016

--- a/content/rdp/2016/rdp_2016-02-12.md
+++ b/content/rdp/2016/rdp_2016-02-12.md
@@ -5,6 +5,7 @@ categories: ["revue de presse"]
 date: 2016-02-12
 description: "Revue de presse du 12 Février"
 tags:
+  - unknown
 ---
 
 # Revue de presse du 12 Février 2016

--- a/content/rdp/2016/rdp_2016-02-19.md
+++ b/content/rdp/2016/rdp_2016-02-19.md
@@ -5,6 +5,7 @@ categories: ["revue de presse"]
 date: 2016-02-19
 description: "Revue de presse du 19 février"
 tags:
+  - unknown
 ---
 
 # Revue de presse du 19 février 2016

--- a/content/rdp/2016/rdp_2016-03-04.md
+++ b/content/rdp/2016/rdp_2016-03-04.md
@@ -5,6 +5,7 @@ categories: ["revue de presse"]
 date: 2016-03-04
 description: "Revue de presse du 4 mars"
 tags:
+  - unknown
 ---
 
 # Revue de presse du 4 mars 2016

--- a/content/rdp/2016/rdp_2016-03-11.md
+++ b/content/rdp/2016/rdp_2016-03-11.md
@@ -5,6 +5,7 @@ categories: ["revue de presse"]
 date: 2016-03-11
 description: "Revue de presse du 11 Mars"
 tags:
+  - unknown
 ---
 
 # Revue de presse du 11 Mars 2016

--- a/content/rdp/2016/rdp_2016-04-22.md
+++ b/content/rdp/2016/rdp_2016-04-22.md
@@ -5,6 +5,7 @@ categories: ["revue de presse"]
 date: 2016-04-22
 description: "Revue de presse du 15 Avril"
 tags:
+  - unknown
 ---
 
 # Revue de presse du 15 Avril 2016

--- a/content/rdp/2016/rdp_2016-06-24.md
+++ b/content/rdp/2016/rdp_2016-06-24.md
@@ -5,6 +5,7 @@ categories: ["revue de presse"]
 date: 2016-06-24
 description: "Revue de presse du 24 juin"
 tags:
+  - unknown
 ---
 
 # Revue de presse du 24 juin 2016

--- a/content/rdp/2016/rdp_2016-07-01.md
+++ b/content/rdp/2016/rdp_2016-07-01.md
@@ -5,6 +5,7 @@ categories: ["revue de presse"]
 date: 2016-07-01
 description: "Revue de presse du 1 juillet"
 tags:
+  - unknown
 ---
 
 # Revue de presse du 1 juillet 2016

--- a/content/rdp/2016/rdp_2016-10-07.md
+++ b/content/rdp/2016/rdp_2016-10-07.md
@@ -5,6 +5,7 @@ categories: ["revue de presse"]
 date: 2016-10-07
 description: "Revue de presse du 7 octobre"
 tags:
+  - unknown
 ---
 
 # Revue de presse du 7 octobre 2016

--- a/content/rdp/2016/rdp_2016-10-14.md
+++ b/content/rdp/2016/rdp_2016-10-14.md
@@ -5,6 +5,7 @@ categories: ["revue de presse"]
 date: 2016-10-14
 description: "Revue de presse du 28 octobre"
 tags:
+  - unknown
 ---
 
 # Revue de presse du 28 octobre 2016

--- a/content/rdp/2016/rdp_2016-12-05.md
+++ b/content/rdp/2016/rdp_2016-12-05.md
@@ -5,6 +5,7 @@ categories: ["revue de presse"]
 date: 2016-12-05
 description: "Revue de Presse du 16 Décembre"
 tags:
+  - unknown
 ---
 
 # Revue de Presse du 16 Décembre 2016

--- a/content/rdp/2017/rdp_2017-01-27.md
+++ b/content/rdp/2017/rdp_2017-01-27.md
@@ -5,6 +5,7 @@ categories: ["revue de presse"]
 date: 2017-01-27
 description: "Revue de presse du 27 janvier"
 tags:
+  - unknown
 ---
 
 # Revue de presse du 27 janvier 2017

--- a/content/tags.md
+++ b/content/tags.md
@@ -1,0 +1,10 @@
+---
+title: "Taxonomie"
+license: none
+---
+
+# Taxonomie
+
+Classement des contenus par mots-clés.
+
+[TAGS]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,8 @@ plugins:
         # recent moves
         "acknowledgements.md": "team/index.md"
         "install_webapp.md": "articles/2020/2020-03-20_installer_site_comme_application.md"
+  - tags:
+      tags_file: tags.md
 
 # Theme
 theme:


### PR DESCRIPTION
Active la taxonomie dans les contenus :

- mots-clés définis dans l'en-tête du contenu avec  `tags`
- une page liste les mots-clés et chaque contenu associé
- les mots-clés apparaissent dans la recherche

Problèmes à résoudre :

- [ ] contenus sans aucun tag mais avec la balise : ajouter des tags
- [ ] corriger la syntaxe des tags écrits dans une seule chaîne de caractères :

Ceci :

```yaml
tags: QGIS,PostGIS,PostgreSQL,bus
```

Doit donner cela :

```yaml
tags:
  - QGIS
  - PostGIS
  - PostgreSQL
  - bus
```