### PR TITLE
retrait news geotrek

### DIFF
--- a/content/rdp/2021/rdp_2021-10-22.md
+++ b/content/rdp/2021/rdp_2021-10-22.md
@@ -195,7 +195,7 @@ Une idée de cadeau à rajouter dans la liste de Noël pour les plus patients!
 - [Lizmap pgRouting module 0.2](https://github.com/3liz/lizmap-pgrouting-module/releases) et [Lizmap module de gestion d'une base adresse 0.9](https://github.com/3liz/qgis-gestion_base_adresse-plugin/releases/tag/0.9.0)
 - [OpenLayers v6.9.0](https://github.com/openlayers/openlayers/releases/tag/v6.9.0)
 - [pgAdmin 4 Version 6.0](https://www.pgadmin.org/docs/pgadmin4/6.0/release_notes_6_0.html)
-- [Rencontres nationales GEOTREK 2021](https://www.crige-paca.org/events/geotrek/)
+
 
 <!-- Intègre le glossaire centralisé -->
 --8<-- "content/toc_nav_ignored/snippets/glossaire.md"


### PR DESCRIPTION
renvoi sur une prog d'un évènement deja passé = pas utile.
A mettre dès que le retour sur l'évènement sera sorti