### PR TITLE
Remplacement du bloc auteur manuel par le centralisé

### DIFF
--- a/content/articles/2008/art_2008-11-03.md
+++ b/content/articles/2008/art_2008-11-03.md
@@ -38,7 +38,4 @@ En cadeau (bonux) mes principales sources d'informations dans le vaste (*and wil
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2008/art_2008-11-05.md
+++ b/content/articles/2008/art_2008-11-05.md
@@ -29,7 +29,4 @@ Il ne vous reste plus qu'a vous lancer à vos claviers et (re)découvrir cette m
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2008/art_2008-11-07.md
+++ b/content/articles/2008/art_2008-11-07.md
@@ -36,7 +36,4 @@ Vous pouvez vous rendre directement sur le site à l'adresse suivante : [PyWPS](
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2008/art_2008-11-17.md
+++ b/content/articles/2008/art_2008-11-17.md
@@ -22,7 +22,4 @@ Pour ceux qui se posent ce genre de question, le [workshop de QGIS](http://softl
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2008/art_2008-12-06.md
+++ b/content/articles/2008/art_2008-12-06.md
@@ -28,7 +28,4 @@ Merci pour cette nouvelle ressource qui prouve que l'Open-Source n'est pas seule
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2008/art_2008-12-07.md
+++ b/content/articles/2008/art_2008-12-07.md
@@ -57,7 +57,4 @@ En cadeau quelques sites permettant de télécharger librement des données SIG 
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2008/art_2008-12-11.md
+++ b/content/articles/2008/art_2008-12-11.md
@@ -32,7 +32,4 @@ Néanmoins, si GeoExt rencontre le même succès qu'OpenLayers et EXT celle-ci d
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2008/art_2008-12-16.md
+++ b/content/articles/2008/art_2008-12-16.md
@@ -32,7 +32,4 @@ Plus d'infos sur :
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-01-13.md
+++ b/content/articles/2009/art_2009-01-13.md
@@ -26,7 +26,4 @@ Outre le fait qu'il soit écrit en PHP l'originalité de cet outil est de pouvoi
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-01-14.md
+++ b/content/articles/2009/art_2009-01-14.md
@@ -31,7 +31,4 @@ La vidéo ci-dessous présente les possibilités de cette nouvelle application :
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-01-21.md
+++ b/content/articles/2009/art_2009-01-21.md
@@ -28,7 +28,4 @@ Merci encore Stefan Steiniger pour cette initiative.
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-01-26.md
+++ b/content/articles/2009/art_2009-01-26.md
@@ -26,7 +26,4 @@ Un interview à lire absolument surtout qu'il est donné par un des Monsieur du 
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-02-01.md
+++ b/content/articles/2009/art_2009-02-01.md
@@ -101,7 +101,4 @@ Faux, l'opposé du logiciel libre est le logiciel propriétaire. La commercialis
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-02-09.md
+++ b/content/articles/2009/art_2009-02-09.md
@@ -62,7 +62,4 @@ Les quelques captures d'écran ci-dessous vous donneront je l'espère l'envie de
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-03-03.md
+++ b/content/articles/2009/art_2009-03-03.md
@@ -44,7 +44,4 @@ Liens utiles :
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-03-05.md
+++ b/content/articles/2009/art_2009-03-05.md
@@ -59,7 +59,4 @@ Source :
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-03-18.md
+++ b/content/articles/2009/art_2009-03-18.md
@@ -24,7 +24,4 @@ Cet article offre ainsi une bonne introduction à tous ceux qui souhaiteraient c
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-03-23.md
+++ b/content/articles/2009/art_2009-03-23.md
@@ -30,7 +30,4 @@ Pense-bête d'OpenLayers :
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-03-24.md
+++ b/content/articles/2009/art_2009-03-24.md
@@ -28,7 +28,4 @@ C'est à cet objectif que s'est attelé "[Geospatial Revolution Project](http://
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-03-26.md
+++ b/content/articles/2009/art_2009-03-26.md
@@ -42,7 +42,4 @@ Parce que d'autres l'on dit bien mieux que moi, je vous conseille également ces
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-03-31.md
+++ b/content/articles/2009/art_2009-03-31.md
@@ -28,7 +28,4 @@ Ma vidéo préférée ? J'hésite entre les deux ci-dessous ? Et vous laquelle e
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-04-01.md
+++ b/content/articles/2009/art_2009-04-01.md
@@ -33,7 +33,4 @@ Au fait, l'erreur... pas très compliquée et entièrement de ma faute (à toujo
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-04-02.md
+++ b/content/articles/2009/art_2009-04-02.md
@@ -26,7 +26,4 @@ Ce genre d'initiative mérite toute notre attention car la protection de la natu
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-04-14.md
+++ b/content/articles/2009/art_2009-04-14.md
@@ -33,7 +33,4 @@ Je viens de découvrir cette nouvelle application, [Marine Map](http://www.marin
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-04-16.md
+++ b/content/articles/2009/art_2009-04-16.md
@@ -48,7 +48,4 @@ Malheureusement pour nos amis linuxiens et moi-même, cet outil n'est disponible
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-04-18.md
+++ b/content/articles/2009/art_2009-04-18.md
@@ -32,7 +32,4 @@ Malheureusement cette application n'est disponible que pour l'Angleterre. Mais p
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-04-22.md
+++ b/content/articles/2009/art_2009-04-22.md
@@ -51,7 +51,4 @@ Google avec O3D a pour objectif de créer un nouveau standard Web. Mais, avec l'
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-04-26.md
+++ b/content/articles/2009/art_2009-04-26.md
@@ -26,7 +26,4 @@ Pour ma part, je pense passer un peu de temps dessus et voir les potentialités 
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-05-05.md
+++ b/content/articles/2009/art_2009-05-05.md
@@ -30,7 +30,4 @@ Une bonne nouvelle n'arrivant jamais seule j'ai eu le plaisir, ce matin, de déc
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-05-15.md
+++ b/content/articles/2009/art_2009-05-15.md
@@ -36,7 +36,4 @@ PS : Si vous souhaitez voter pour le site GeoTribu n'hésitez pas ça se passe [
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-05-19.md
+++ b/content/articles/2009/art_2009-05-19.md
@@ -42,7 +42,4 @@ En conclusion, j'estime que les quelques jours passés à la compréhension de c
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-05-24.md
+++ b/content/articles/2009/art_2009-05-24.md
@@ -61,7 +61,4 @@ En conclusion, je classerai Puzzle-GIS dans la catégorie viewer. Les fonctionna
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-05-25.md
+++ b/content/articles/2009/art_2009-05-25.md
@@ -25,7 +25,4 @@ Cette initiative montre bien le glissement des mentalités vers de la coopérati
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-05-31.md
+++ b/content/articles/2009/art_2009-05-31.md
@@ -78,7 +78,4 @@ C'est sur une note très positive que je finirai ce billet. OpenJump a les moyen
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-06-02.md
+++ b/content/articles/2009/art_2009-06-02.md
@@ -27,7 +27,4 @@ A quand la même chose pour python? Cela risque d'être tout de même plus compl
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-06-04.md
+++ b/content/articles/2009/art_2009-06-04.md
@@ -44,7 +44,4 @@ Au final, avec cette nouvelle version toute l'équipe de GeoServer nous offre un
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-06-05.md
+++ b/content/articles/2009/art_2009-06-05.md
@@ -55,7 +55,4 @@ Je vous laisse regarder la vidéo assez impressionnante (environ 1h20 !)
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-06-07.md
+++ b/content/articles/2009/art_2009-06-07.md
@@ -79,7 +79,4 @@ Pour le moment, je dois avouer que c'est UDIG qui me convient le plus. Seul poin
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-06-18.md
+++ b/content/articles/2009/art_2009-06-18.md
@@ -27,7 +27,4 @@ Nous en sommes, à l'heure où j'écris ces lignes, à la version 0.5. J'ai hât
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-06-23.md
+++ b/content/articles/2009/art_2009-06-23.md
@@ -25,7 +25,4 @@ Félicitations à toute l'équipe d'OpenLayers et rendez-vous sur GéoTribu pour
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-06-24.md
+++ b/content/articles/2009/art_2009-06-24.md
@@ -35,7 +35,4 @@ Ces nouvelles versions sont une preuve supplémentaire de la maturité du monde 
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-07-01.md
+++ b/content/articles/2009/art_2009-07-01.md
@@ -39,7 +39,4 @@ Au final, j'espère que ce premier pas de l'IGN s'enrichira de nouvelles donnée
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-07-12.md
+++ b/content/articles/2009/art_2009-07-12.md
@@ -33,7 +33,4 @@ Dans la logique de ce billet, [Slashgeo](http://slashgeo.org/)a également publi
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-07-15.md
+++ b/content/articles/2009/art_2009-07-15.md
@@ -34,7 +34,4 @@ Si vous en connaissez d'autres je suis bien évidemment preneur !
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-07-17.md
+++ b/content/articles/2009/art_2009-07-17.md
@@ -56,7 +56,4 @@ Ces nouvelles applications OpenSource sont une véritable opportunité pour le m
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-07-19.md
+++ b/content/articles/2009/art_2009-07-19.md
@@ -25,7 +25,4 @@ Néanmoins une chose est certaine l'année prochaine j'y serai ! J'aurai ainsi l
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-07-21.md
+++ b/content/articles/2009/art_2009-07-21.md
@@ -78,7 +78,4 @@ Autre ressource :
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-07-26.md
+++ b/content/articles/2009/art_2009-07-26.md
@@ -26,7 +26,4 @@ Enfin, je vous invite également à consulter le [comparatif](http://maker.geoco
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-08-03.md
+++ b/content/articles/2009/art_2009-08-03.md
@@ -40,7 +40,4 @@ Au final, la découverte de ces deux applications à quelques jours d'intervalle
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-08-06.md
+++ b/content/articles/2009/art_2009-08-06.md
@@ -32,7 +32,4 @@ Au-delà de l'aspect simpliste de ce questionnaire, c'est une bonne chose pour l
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-08-10.md
+++ b/content/articles/2009/art_2009-08-10.md
@@ -63,7 +63,4 @@ Comme je vous le disais en préambule, beaucoup de changements ont eu lieu. Rest
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-08-17.md
+++ b/content/articles/2009/art_2009-08-17.md
@@ -30,7 +30,4 @@ Néanmoins, j'avoue être un peu déçu par cette nouvelle version. En effet, d�
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-08-20.md
+++ b/content/articles/2009/art_2009-08-20.md
@@ -34,7 +34,4 @@ OpenStreetMap, ce véritable phénomène de société qui a conduit le citoyen l
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-09-02.md
+++ b/content/articles/2009/art_2009-09-02.md
@@ -90,7 +90,4 @@ Je profite de ce post pour vous annoncer que je quitterai bientôt mon île pour
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-09-04.md
+++ b/content/articles/2009/art_2009-09-04.md
@@ -117,7 +117,4 @@ Il y a un nouveau terminal GRASS ainsi que beaucoup de nettoyage et d'améliorat
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-09-09.md
+++ b/content/articles/2009/art_2009-09-09.md
@@ -65,7 +65,4 @@ Cette nouvelle version de QGis apporte son lot de nouveautés et de surprises. J
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-09-11.md
+++ b/content/articles/2009/art_2009-09-11.md
@@ -35,7 +35,4 @@ Cet outil, en plus d'être simple d'utilisation, offre un service des plus utile
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-09-15.md
+++ b/content/articles/2009/art_2009-09-15.md
@@ -23,7 +23,4 @@ De nombreux articles mettant en avant la puissance jumelée de ces nouvelles ver
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-09-25.md
+++ b/content/articles/2009/art_2009-09-25.md
@@ -26,7 +26,4 @@ Au delà de ce manuel, je salue l'important travail réalisé par l'OSGEO-fr dan
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-09-27.md
+++ b/content/articles/2009/art_2009-09-27.md
@@ -32,7 +32,4 @@ Par contre, la jouabilité est assez complexe. N'hésitez donc pas à consulter 
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-09-30.md
+++ b/content/articles/2009/art_2009-09-30.md
@@ -33,7 +33,4 @@ Décidément les applications gravitant autour d'OpenStreetMap ne cesse de s'enc
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-10-10.md
+++ b/content/articles/2009/art_2009-10-10.md
@@ -24,7 +24,4 @@ tags:
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-10-16.md
+++ b/content/articles/2009/art_2009-10-16.md
@@ -36,7 +36,4 @@ Cette nouvelle version est d'ores et déjà [librement téléchargeable](http://
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-10-28.md
+++ b/content/articles/2009/art_2009-10-28.md
@@ -36,7 +36,4 @@ Par rapport à d'autres applications orientées cartographie (AndNav 2, Nav4All.
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-10-29.md
+++ b/content/articles/2009/art_2009-10-29.md
@@ -31,7 +31,4 @@ Les conclusions de ce Benchmarks, disponibles en [ligne](https://www.slideshare.
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-10-30.md
+++ b/content/articles/2009/art_2009-10-30.md
@@ -38,7 +38,4 @@ Je pense que je vais réutiliser souvent cet outil surtout dans le cadre de pré
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-11-04.md
+++ b/content/articles/2009/art_2009-11-04.md
@@ -29,7 +29,4 @@ L'interface du site est agréable utiliser et les choix de sélection sont plut�
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-11-09.md
+++ b/content/articles/2009/art_2009-11-09.md
@@ -29,7 +29,4 @@ Cet utilitaire fait donc partie des indispensables de la boite à outil du géom
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-11-11.md
+++ b/content/articles/2009/art_2009-11-11.md
@@ -29,7 +29,4 @@ L'image ci-dessous est un petit clin d'œil pour MapFish en rappel de leur ancie
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-11-15.md
+++ b/content/articles/2009/art_2009-11-15.md
@@ -29,7 +29,4 @@ Néanmoins, si cette carte présente de manière synthétique les liens entre le
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-11-23.md
+++ b/content/articles/2009/art_2009-11-23.md
@@ -39,7 +39,4 @@ Cette liste loin d'être exhaustive n'est qu'un aperçu de réalisations que nou
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-11-26.md
+++ b/content/articles/2009/art_2009-11-26.md
@@ -86,7 +86,4 @@ Au final, je dois avouer que c'est sur une excellente appréciation que je finis
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-12-11.md
+++ b/content/articles/2009/art_2009-12-11.md
@@ -43,7 +43,4 @@ Allé pour finir un petit gout de CSS 3 et notamment de la propriété transitio
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-12-29.md
+++ b/content/articles/2009/art_2009-12-29.md
@@ -39,7 +39,4 @@ Edit : ça y est j'ai retrouvé le lien qui invitait au projet : <http://geomart
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2009/art_2009-12-31.md
+++ b/content/articles/2009/art_2009-12-31.md
@@ -50,7 +50,4 @@ Et voilà, il ne vous reste plus qu'à faire joujou !
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-01-08.md
+++ b/content/articles/2010/art_2010-01-08.md
@@ -54,7 +54,4 @@ Le seul bémol avec l'ouverture au monde entier c'est que le temps d'attente pou
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-01-12.md
+++ b/content/articles/2010/art_2010-01-12.md
@@ -35,7 +35,4 @@ Le hic - parce qu'il y en a un - c'est le [prix](http://www.heatmapapi.com/FAQ.a
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-01-18.md
+++ b/content/articles/2010/art_2010-01-18.md
@@ -42,7 +42,4 @@ En constante évolution, QGIS continue à me satisfaire totalement dans l'exécu
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-01-25.md
+++ b/content/articles/2010/art_2010-01-25.md
@@ -34,7 +34,4 @@ Afin d'améliorer ce service, nous vous invitons à poster vos remarques, nous �
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-02-02.md
+++ b/content/articles/2010/art_2010-02-02.md
@@ -37,7 +37,4 @@ La version payante permet d'enregistrer 100 traces contre 1 pour la version grat
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-02-04.md
+++ b/content/articles/2010/art_2010-02-04.md
@@ -75,7 +75,4 @@ Enfin, reste la question du [prix](http://opengeo.org/products/suite/buy/#price)
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-02-05.md
+++ b/content/articles/2010/art_2010-02-05.md
@@ -31,7 +31,4 @@ Evidemment, ça fonctionne aussi sur iPhone et Android ! C'est toute la magie de
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-02-11.md
+++ b/content/articles/2010/art_2010-02-11.md
@@ -59,7 +59,4 @@ Enfin, pour illustrer ce billet, nous avons écrit 5 tutoriaux pour mieux appré
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-02-12.md
+++ b/content/articles/2010/art_2010-02-12.md
@@ -24,7 +24,4 @@ Les bénéfices apportés par l'OpenSource et surtout par la communauté qui se 
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-02-15.md
+++ b/content/articles/2010/art_2010-02-15.md
@@ -42,7 +42,4 @@ Daniel Weiner, Trevor M. Harris , William J. Craig 2002. Community Participation
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-03-02.md
+++ b/content/articles/2010/art_2010-03-02.md
@@ -105,7 +105,4 @@ Atol 2008, Livre blanc ([+](http://www.atolcd.com/actualites/detail-actualite/ac
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-03-11.md
+++ b/content/articles/2010/art_2010-03-11.md
@@ -32,7 +32,4 @@ Ainsi, en à peine le temps d'un téléchargement, vous avez à votre dispositio
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-03-12.md
+++ b/content/articles/2010/art_2010-03-12.md
@@ -34,7 +34,4 @@ Chacune de ces librairies possède ces avantages et ces inconvénients, c'est av
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-03-15.md
+++ b/content/articles/2010/art_2010-03-15.md
@@ -49,7 +49,4 @@ Sources : [Ajaxian](http://ajaxian.com/archives/yql-geo-library-all-your-geo-nee
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-03-17.md
+++ b/content/articles/2010/art_2010-03-17.md
@@ -32,7 +32,4 @@ Vous trouverez tous les renseignements nécessaires en consultant [l'annonce off
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-03-18.md
+++ b/content/articles/2010/art_2010-03-18.md
@@ -33,7 +33,4 @@ Assisterions-nous également au rapprochement de deux mondes, celui de la [Palé
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-03-25.md
+++ b/content/articles/2010/art_2010-03-25.md
@@ -36,7 +36,4 @@ La [version 1.0](http://trac.geoext.org/milestone/1.0) de GeoExt se profile à l
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-03-31.md
+++ b/content/articles/2010/art_2010-03-31.md
@@ -42,7 +42,4 @@ Les candidats ont jusqu’au 30 avril 2010 pour prendre contact avec le laborato
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-04-06.md
+++ b/content/articles/2010/art_2010-04-06.md
@@ -30,7 +30,4 @@ Pour visualiser le cube, un navigateur récent est obligatoire.
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-04-08.md
+++ b/content/articles/2010/art_2010-04-08.md
@@ -26,7 +26,4 @@ Si le monde de l'OpenSource vous intéresse, si soutenir une association utile v
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-04-12.md
+++ b/content/articles/2010/art_2010-04-12.md
@@ -51,7 +51,4 @@ Et voilà ! Quelques longues minutes plus tard, vous êtes en possession d'un no
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-04-23.md
+++ b/content/articles/2010/art_2010-04-23.md
@@ -133,7 +133,4 @@ Dans un prochain billet, nous verrons comment lier GeoScript et Narwhal avec un 
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-04-26.md
+++ b/content/articles/2010/art_2010-04-26.md
@@ -36,7 +36,4 @@ La prochaine étape ? La tant attendu version 3.0 ! En attendant il ne reste plu
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-05-04.md
+++ b/content/articles/2010/art_2010-05-04.md
@@ -39,7 +39,4 @@ Si vous souhaitez consulter la liste complète des améliorations, celle-ci est 
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-05-11.md
+++ b/content/articles/2010/art_2010-05-11.md
@@ -133,7 +133,4 @@ La rencontre avec les experts de Google a fait le plein
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-05-13.md
+++ b/content/articles/2010/art_2010-05-13.md
@@ -30,7 +30,4 @@ La version 1.0 approche à grands pas. Que de chemin parcouru depuis cette simpl
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-05-28.md
+++ b/content/articles/2010/art_2010-05-28.md
@@ -106,7 +106,4 @@ Ici nous avons utilisé la classe Strategy Cluster d'OpenLayers pour représente
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-06-02.md
+++ b/content/articles/2010/art_2010-06-02.md
@@ -41,7 +41,4 @@ suivante :*
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-06-07.md
+++ b/content/articles/2010/art_2010-06-07.md
@@ -79,7 +79,4 @@ Merci à Patrick Hochstenbach pour avoir publié ce [billet](http://www.use-it.b
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-06-11.md
+++ b/content/articles/2010/art_2010-06-11.md
@@ -56,7 +56,4 @@ Détaillons un peu plus en détails chacune des sous balises :
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-06-22.md
+++ b/content/articles/2010/art_2010-06-22.md
@@ -72,7 +72,4 @@ En conclusion, je pense que les mouvements auxquels nous assistons en ce moment 
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-06-24.md
+++ b/content/articles/2010/art_2010-06-24.md
@@ -41,7 +41,4 @@ Lors de vos contacts, merci de mentionner l'association Bernard Gregory et la r�
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-07-06.md
+++ b/content/articles/2010/art_2010-07-06.md
@@ -28,7 +28,4 @@ Pour les possesseurs d'un téléphone Android participant à OpenStreetMap, cett
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-07-21.md
+++ b/content/articles/2010/art_2010-07-21.md
@@ -79,7 +79,4 @@ Au fait, le site dans sa version PC, ça fonctionne bien mieux sur des navigateu
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-08-18.md
+++ b/content/articles/2010/art_2010-08-18.md
@@ -28,7 +28,4 @@ Si tout comme nous vous êtes persuadé que l'information citoyenne doit être v
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-08-25.md
+++ b/content/articles/2010/art_2010-08-25.md
@@ -103,7 +103,4 @@ L'installation ainsi que la prise en main de gsconfig sont réellement très rap
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-09-03.md
+++ b/content/articles/2010/art_2010-09-03.md
@@ -53,7 +53,4 @@ http://localhost/cgi-bin/world-analyse/qgis\_mapserv.fcgi?SERVICE=WMS&VERSION=1.
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-09-23.md
+++ b/content/articles/2010/art_2010-09-23.md
@@ -286,7 +286,4 @@ L'intérêt technique de ce plugin est très limité. Mais l'objectif était de 
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-09-30.md
+++ b/content/articles/2010/art_2010-09-30.md
@@ -26,7 +26,4 @@ Grâce à celui-ci, vous pourrez sélectionner les différentes classes que vous
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-10-18.md
+++ b/content/articles/2010/art_2010-10-18.md
@@ -66,7 +66,4 @@ L'arrêt pour l'Ecole des Mines s'intitule « Place Sophie Laffitte ».
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-11-10.md
+++ b/content/articles/2010/art_2010-11-10.md
@@ -29,7 +29,4 @@ Pour ceux qui ne pourront s'y rendre, rassurez-vous nous vous ferons un récapit
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-11-18.md
+++ b/content/articles/2010/art_2010-11-18.md
@@ -55,7 +55,4 @@ Il me reste à conclure ce billet et surtout à aller dormir car demain s'annonc
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-11-19.md
+++ b/content/articles/2010/art_2010-11-19.md
@@ -40,7 +40,4 @@ Cette seconde journée, s'est ensuite terminée par une visite de Toulouse et un
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-11-20.md
+++ b/content/articles/2010/art_2010-11-20.md
@@ -32,7 +32,4 @@ Ce colloque se termine, et il est temps de retourner dans le Sud. En tout cas, j
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-11-24.md
+++ b/content/articles/2010/art_2010-11-24.md
@@ -48,7 +48,4 @@ Cliquez sur l'image pour lancer l'application :-)
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-11-29.md
+++ b/content/articles/2010/art_2010-11-29.md
@@ -27,7 +27,4 @@ tags:
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-12-13.md
+++ b/content/articles/2010/art_2010-12-13.md
@@ -45,7 +45,4 @@ Cliquez sur l'image pour lancer l'application :-)
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2010/art_2010-12-20.md
+++ b/content/articles/2010/art_2010-12-20.md
@@ -35,7 +35,4 @@ Flashouillez le QR code pour aller sur la page :-) ou sinon l'adresse c'est <htt
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2011/art_2011-01-09.md
+++ b/content/articles/2011/art_2011-01-09.md
@@ -34,7 +34,4 @@ A lire également [les 10 autres livres de la collection](http://owni.fr/2010/12
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2011/art_2011-01-18.md
+++ b/content/articles/2011/art_2011-01-18.md
@@ -32,7 +32,4 @@ Merci d'envoyer vos candidatures (CV + lettre de motivation) à [aldo.napoli@crc
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2011/art_2011-01-19.md
+++ b/content/articles/2011/art_2011-01-19.md
@@ -127,7 +127,4 @@ Ce dernier exercice complémentaire met d'ailleurs en évidence un manque en ter
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2011/art_2011-01-24.md
+++ b/content/articles/2011/art_2011-01-24.md
@@ -139,7 +139,4 @@ Mais nous n'avons pas testé le SVG qui fait sa spécificité. Nous essaierons d
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2011/art_2011-02-09.md
+++ b/content/articles/2011/art_2011-02-09.md
@@ -69,7 +69,4 @@ La génération des images utilise le moteur de style [Osmarender](https://wiki.
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2011/art_2011-03-10.md
+++ b/content/articles/2011/art_2011-03-10.md
@@ -28,7 +28,4 @@ View more [presentations](https://www.slideshare.net/) from [arno974](https://ww
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2011/art_2011-03-23.md
+++ b/content/articles/2011/art_2011-03-23.md
@@ -144,7 +144,4 @@ L'utilisation de SQLite et de Spatialite m'a impressionné par sa simplicité. L
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2011/art_2011-04-05.md
+++ b/content/articles/2011/art_2011-04-05.md
@@ -82,7 +82,4 @@ WebGL Earth est un projet récent. Cela explique notamment le peu de fonctionnal
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2011/art_2011-04-13.md
+++ b/content/articles/2011/art_2011-04-13.md
@@ -48,7 +48,4 @@ Il existe certainement des services similaires. En connaissez-vous d'autres ? Le
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2011/art_2011-06-01.md
+++ b/content/articles/2011/art_2011-06-01.md
@@ -51,7 +51,4 @@ Aldo NAPOLI, chargé de recherche au CRC de Mines ParisTech
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2011/art_2011-06-10.md
+++ b/content/articles/2011/art_2011-06-10.md
@@ -30,7 +30,4 @@ En somme, c'est un ouvrage à mettre entre toutes les mains qui permettra de dé
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2011/art_2011-06-15.md
+++ b/content/articles/2011/art_2011-06-15.md
@@ -178,7 +178,4 @@ Leaflet est une librairie Javascript bien sympathique dont la prise en main est 
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2011/art_2011-07-27.md
+++ b/content/articles/2011/art_2011-07-27.md
@@ -80,7 +80,4 @@ Pour plus d'informations, n'hésitez pas à consulter :
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2011/art_2011-11-08.md
+++ b/content/articles/2011/art_2011-11-08.md
@@ -291,7 +291,4 @@ tags:
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2011/art_2011-12-01.md
+++ b/content/articles/2011/art_2011-12-01.md
@@ -24,7 +24,4 @@ View more [presentations](https://www.slideshare.net/) from [arno974](https://ww
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2012/art_2012-01-01.md
+++ b/content/articles/2012/art_2012-01-01.md
@@ -22,7 +22,4 @@ tags:
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2012/art_2012-01-16.md
+++ b/content/articles/2012/art_2012-01-16.md
@@ -20,7 +20,4 @@ tags:
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2012/art_2012-01-19.md
+++ b/content/articles/2012/art_2012-01-19.md
@@ -40,7 +40,4 @@ Et vous quel est votre avis ?
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2012/art_2012-02-03.md
+++ b/content/articles/2012/art_2012-02-03.md
@@ -27,7 +27,4 @@ A voir maintenant, si cette décision fera jurisprudence.
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2012/art_2012-03-15.md
+++ b/content/articles/2012/art_2012-03-15.md
@@ -61,7 +61,4 @@ Quand je vous disais qu'elle était un peu triste notre carte OSM de la réunion
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2012/art_2012-04-17.md
+++ b/content/articles/2012/art_2012-04-17.md
@@ -378,7 +378,4 @@ Si vous avez des remarques et / ou des suggestions, vous pouvez sans problème l
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2012/art_2012-05-09.md
+++ b/content/articles/2012/art_2012-05-09.md
@@ -188,7 +188,4 @@ Au-delà de notre "petit" test, lecteur de géotribu, avez-vous déjà essayé c
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2012/art_2012-06-06.md
+++ b/content/articles/2012/art_2012-06-06.md
@@ -28,7 +28,4 @@ Au-delà de cette offre, c'est l'aspect marketing que j'ai bien aimé. On voit q
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2012/art_2012-07-02.md
+++ b/content/articles/2012/art_2012-07-02.md
@@ -49,7 +49,4 @@ Sur le papier, la solution proposée par [Isogeo](http://www.isogeo.fr) apparaî
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2012/art_2012-07-05.md
+++ b/content/articles/2012/art_2012-07-05.md
@@ -45,7 +45,4 @@ Presque 20h30 et cette conférence s'est achevée par un chaleureux cocktail. Bi
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2012/art_2012-07-12.md
+++ b/content/articles/2012/art_2012-07-12.md
@@ -36,7 +36,4 @@ Quoi qu'il en soit, c'est du beau boulot et je dois saluer l'effort porté sur l
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2012/art_2012-07-19.md
+++ b/content/articles/2012/art_2012-07-19.md
@@ -24,7 +24,4 @@ Cette conférence se veut être un véritable espace de rencontres, d'expression
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2012/art_2012-09-26.md
+++ b/content/articles/2012/art_2012-09-26.md
@@ -27,7 +27,4 @@ De nombreux cas pratiques illustrent ces différents chapitres et les codes asso
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2012/art_2012-10-11.md
+++ b/content/articles/2012/art_2012-10-11.md
@@ -50,7 +50,4 @@ En plus d'avoir contribué à plusieurs transferts technologiques vers l'industr
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2012/art_2012-10-23.md
+++ b/content/articles/2012/art_2012-10-23.md
@@ -55,7 +55,4 @@ Yan, Zhixian. 2011. “Semantic Trajectories: Computing and Understanding Mobili
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2012/art_2012-12-29.md
+++ b/content/articles/2012/art_2012-12-29.md
@@ -34,7 +34,4 @@ Pour ceux qui se demandent quelles sont les résolutions de GéoTribu pour l'ann
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2013/art_2013-02-11.md
+++ b/content/articles/2013/art_2013-02-11.md
@@ -42,7 +42,4 @@ Les présentations seront faites en français. Les résumés seront évalués pa
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2013/art_2013-03-07.md
+++ b/content/articles/2013/art_2013-03-07.md
@@ -32,7 +32,4 @@ La précédente édition des Rencontres, en juin 2011, avait réuni près de 300
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2013/art_2013-05-29.md
+++ b/content/articles/2013/art_2013-05-29.md
@@ -39,7 +39,4 @@ L'evénement est accessible ici : **[GéoInterview de David Jonglez](https://plu
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2013/art_2013-08-16.md
+++ b/content/articles/2013/art_2013-08-16.md
@@ -26,7 +26,4 @@ Aaarrgggghhh ... pas de revue de presse ce vendredi ... Ca fait bien longtemps q
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2013/art_2013-10-02.md
+++ b/content/articles/2013/art_2013-10-02.md
@@ -50,7 +50,4 @@ Bon, ceci étant dit étant passé, revenons à l'objet principal de ce billet q
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2013/art_2013-12-01.md
+++ b/content/articles/2013/art_2013-12-01.md
@@ -66,7 +66,4 @@ Tous les travaux du stage sont CONFIDENTIELS et sont l'entière propriété de A
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2014/art_2014-01-01.md
+++ b/content/articles/2014/art_2014-01-01.md
@@ -56,7 +56,4 @@ Pour les [GéoInterviews](http://geotribu.net/geointerview), nous avions au dép
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2014/art_2014-03-07.md
+++ b/content/articles/2014/art_2014-03-07.md
@@ -34,7 +34,4 @@ Alors n'oubliez pas : si vous êtes une entreprise, une association ou autres, e
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2014/art_2014-07-14.md
+++ b/content/articles/2014/art_2014-07-14.md
@@ -36,7 +36,4 @@ Si vous souhaitez discuter de géomatique (ou autre), rejoignez-nous !
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2014/art_2014-09-01.md
+++ b/content/articles/2014/art_2014-09-01.md
@@ -42,7 +42,4 @@ Délégué Maitrise des Risques
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2015/art_2015-01-18.md
+++ b/content/articles/2015/art_2015-01-18.md
@@ -55,7 +55,4 @@ Study of the History Using Digital Technology    N'hésitez pas à [proposer vot
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2015/art_2015-02-03.md
+++ b/content/articles/2015/art_2015-02-03.md
@@ -89,7 +89,4 @@ Je suis par ailleurs activement à la recherche de contributions financières po
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2015/art_2015-02-04.md
+++ b/content/articles/2015/art_2015-02-04.md
@@ -44,7 +44,4 @@ Les démos sont disponible sur le site dédié [http://openlayersbook.github.io]
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/articles/2015/art_2015-02-09.md
+++ b/content/articles/2015/art_2015-02-09.md
@@ -70,7 +70,4 @@ Repas et collations compris
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"

--- a/content/team/archives/art_2012-12-29_lequipe.md
+++ b/content/team/archives/art_2012-12-29_lequipe.md
@@ -35,7 +35,4 @@ tags:
 
 ## Auteur
 
-![Portait de GeoTribu](https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png){: .img-rdp-news-thumb }
-**GeoTribu**
-
-Toute l'actualité de la géomatique Open Source ! Mais aussi des tutoriels, des billets de blog, des tests et surtout une bonne humeur géographique !
+--8<-- "content/toc_nav_ignored/snippets/authors/geotribu.md"


### PR DESCRIPTION
En mettant en place le mécanisme du bloc auteur centralisé (cf https://static.geotribu.fr/contribuer/guides/authoring/#bloc-auteur), j'avais oublié de changer celui où c'est Geotribu qui est en auteur.

Bref, j'ai fait un gros rechercher/remplacer