### PR TITLE
Fonctionnalité : automatiser la création d'une revue de presse en donnant juste la date

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -36,7 +36,7 @@ Modèle de news ici : https://github.com/geotribu/website/blob/master/content/rd
 
 Exemple de [tweet](https://twitter.com/geotribu/status/1364625815099613185) :
 
-![tweet geordp](https://cdn.geotribu.fr/img/internal/contribution/geotribu_rdp_tweet_incitation.png "exemple de tweet geordp")
+![tweet geordp](https://cdn.geotribu.fr/img/internal/contribution/geotribu_rdp_tweet_incitation.png)
 
 ----
 

--- a/.github/workflows/manual_new_rdp.yml
+++ b/.github/workflows/manual_new_rdp.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           source_branch: rdp/${{ github.event.inputs.date }}
-          destination_branch: "main"
+          destination_branch: "master"
           pr_allow_empty: false
           pr_title: "🗞 GeoRDP du ${{ steps.locale-fr.outputs.date-fr-long }}"
           pr_template: .github/PULL_REQUEST_TEMPLATE.md

--- a/.github/workflows/manual_new_rdp.yml
+++ b/.github/workflows/manual_new_rdp.yml
@@ -1,0 +1,74 @@
+name: "🗞 New GeoRDP"
+
+on:
+  workflow_dispatch:
+    inputs:
+      date:
+        type: string
+        description: Date de la prochaine RDP au format YYYY-MM-DD
+        required: true
+      notify-slack:
+        type: boolean
+        default: true
+        description: Notifier l'équipe sur Slack
+
+env:
+  LANG: "fr_FR.UTF-8"
+  LC_ALL: "fr_FR.UTF-8"
+  LC_TIME: "fr_FR.UTF-8"
+
+jobs:
+  create_rdp:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install French locale
+        id: locale-fr
+        shell: bash
+        run: |
+          sudo locale-gen fr_FR.UTF-8
+          sudo update-locale LANG=fr_FR.UTF-8
+          echo "::set-output name=date-fr-long::$(date -d ${{ github.event.inputs.date }} '+%-d %B %Y')"
+
+      - name: Get source code
+        uses: actions/checkout@v2
+
+      - name: Create a new GeoRDP
+        shell: bash
+        run: bash ./scripts/new_rdp.sh ${{ github.event.inputs.date }}
+
+      - name: New branch
+        run: |
+          git config user.name ${{ github.actor }}
+          git config user.email '${{ github.actor }}@users.noreply.github.com'
+          git checkout -b rdp/${{ github.event.inputs.date }}
+          git status
+
+      - name: Commit new GeoRDP
+        run: |
+          git add content/rdp/
+          git commit -am "Crée la GeoRDP ${{ github.event.inputs.date }}"
+
+      - name: Push to remote
+        run: git push origin rdp/${{ github.event.inputs.date }}
+
+      - name: Create Pull Request
+        id: cpr
+        uses: repo-sync/pull-request@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          source_branch: rdp/${{ github.event.inputs.date }}
+          destination_branch: "main"
+          pr_allow_empty: false
+          pr_title: "🗞 GeoRDP du ${{ steps.locale-fr.outputs.date-fr-long }}"
+          pr_template: .github/PULL_REQUEST_TEMPLATE.md
+
+      - name: Notification Slack
+        id: slack
+        uses: slackapi/slack-github-action@v1.16
+        if: "${{ github.event.inputs.notify-slack == 'true' }}"
+        with:
+          payload: '{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":newspaper: La GeoRDP du ${{ steps.locale-fr.outputs.date-fr-long }} a été créée et attend vos contributions :writing_hand: !"}},{"type":"section","fields":[{"type":"mrkdwn","text":"Créée par *${{ github.actor }}* via GitHub Action."}]},{"type":"actions","elements":[{"type":"button","text":{"type":"plain_text","emoji":true,"text":":squid: Voir la PR (GitHub)"},"url":"${{ steps.cpr.outputs.pr_url }}"},{"type":"button","text":{"type":"plain_text","emoji":true,"text":":eye: Voir la preview (Netlify)"},"style":"primary","url":"https://preview-pullrequest-${{steps.cpr.outputs.pr_number}}--geotribu-preprod.netlify.app/"}]}]}'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/content/contribuer/rdp/create_rdp.md
+++ b/content/contribuer/rdp/create_rdp.md
@@ -21,13 +21,69 @@ tags:
 
 La création d'une revue de presse passe par la création d'une branche dédiée dans le dépôt du site et du fichier Markdown qui contiendra les news dans une structure type. Il est possible de créer en utilisant Git en ligne de commande ou via l'interface web de GitHub.
 
-TL;DR : voici une vidéo retraçant les étapes de création d'une revue de presse via l'interface web de GitHub :
+!!! info "Zone réservée"
+    La création d'une nouvelle revue de presse nécessite de disposer des droits d'écriture sur le dépôt GitHub : [{{ config.repo_name }}]({{ config.repo_url }}).
+
+## Automatiquement via GitHub Workflow
+
+![icône GitHub Actions](https://cdn.geotribu.fr/img/logos-icones/divers/github_actions.png "GitHub Actions"){: .img-rdp-news-thumb }
+
+La méthode la plus simple de créer une nouvelle revue de presse est d'utiliser le workflow *:newspaper2: New GeoRDP* disponible sur GitHub :
+
+1. Se rendre sur l'onglet `Actions` et sélectionner le workflow *:newspaper2: New GeoRDP* ou [cliquer ici]({{ config.repo_url }}actions/workflows/manual_new_rdp.yml)
+2. Cliquer sur `Run workflow`
+3. Entrer les infos demandées :
+    - branche : `master`
+    - date de la revue de presse : doit être au format `YYYY-MM-DD` et pointer sur un vendredi
+    - choisir d'envoyer automatiquement une notification sur Slack
+4. Cliquer sur le bouton vert `Run workflow`.
+
+<!-- markdownlint-disable MD046 -->
+!!! abstract "Prérequis"
+    La bonne exécution du workflow dépend de ces éléments configurés au préalable sur le dépôt :
+
+    - le modèle de Pull Request est bien présent : `.github/PULL_REQUEST_TEMPLATE.md`
+    - que l'URL du webhook de Slack (`SLACK_WEBHOOK_URL`) est bien configuré dans [les secrets du dépôt]({{ config.repo_url }}settings/secrets/actions) (cliquer [ici pour administrer le webhook Slack](https://api.slack.com/apps/A020C9Q93BK/incoming-webhooks/))
+<!-- markdownlint-enable MD046 -->
+
+### Utiliser localement le script intégré localement
+
+Si vous disposez d'un terminal Bash et disposez du dépôt cloné, il est possible d'utiliser le script intégré :
+
+```bash
+# stocker la date de la RDP au format YYYY-MM-DD
+DATE_RDP=2022-01-07
+
+# exécuter le script
+scripts/new_rdp.sh $DATE_RDP
+
+# pousser vers le dépôt distant
+git pull
+git checkout -b rdp/$DATE_RDP
+git add content/rdp/
+git commit -am "Crée la GeoRDP $DATE_RDP"
+git push origin rdp/$DATE_RDP
+```
+
+Ne pas oublier ensuite de :
+
+1. se rendre sur [GitHub pour créer la Pull Request]({{ config.repo_url }}pulls)
+2. sur [le canal dédié aux revues de presse sur Slack](https://geotribu.slack.com/archives/C010DD7FMEX) pour notifier l'équipe
+
+## Manuellement via l'interface web de GitHub
+
+Il est également possible d'utiliser l'ancienne procédure manuelle.  
+Voici une vidéo retraçant les étapes de création d'une revue de presse via l'interface web de GitHub :
 
 <iframe width="100%" height="400" src="https://www.youtube.com/embed/dVpOdGYAtIk" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ----
 
-## Créer la branche de la revue de presse
+## Processus détaillé
+
+Cette partie permet de comprendre chaque étape du processus de création d'une revue de presse.
+
+### 1. Créer la branche de la revue de presse
 
 ![logo Git](https://cdn.geotribu.fr/img/logos-icones/divers/git.png "logo Git"){: .img-rdp-news-thumb }
 
@@ -41,7 +97,7 @@ Il est important de respecter la convention de nommage `rdp/YYYY-MM-DD` où :
 
 Exemple si la GeoRDP devait être publiée le 17 septembre 2021 : `rdp/2021-09-17`.
 
-### :fontawesome-brands-github:  GitHub
+#### :fontawesome-brands-github:  GitHub
 
 Sur l'interface web du dépôt :
 
@@ -51,7 +107,7 @@ Sur l'interface web du dépôt :
 
 ![Github - New branch](https://cdn.geotribu.fr/img/internal/contribution/github_branch_rdp_new.png "GitHub - Création d'une branche"){: .img-center loading=lazy }
 
-### :fontawesome-solid-terminal: Ligne de commande
+#### :fontawesome-solid-terminal: Ligne de commande
 
 Si vous disposez du dépôt localement et que vous préférez utiliser la ligne de commande de [Git], voici les étapes à suivre :
 
@@ -89,7 +145,7 @@ Si vous disposez du dépôt localement et que vous préférez utiliser la ligne 
 
 ----
 
-## Créer le fichier de la revue de presse
+### 2. Créer le fichier de la revue de presse
 
 ![icône globe tricot](https://cdn.geotribu.fr/img/internal/icons-rdp-news/matiere.png "icône globe tricot"){: .img-rdp-news-thumb }
 
@@ -101,7 +157,7 @@ Afin d'accueillir les news, il s'agit de créer un fichier en respectant l'organ
 
 Exemple si la GeoRDP devait être publiée le 17 septembre 2021 : `content/rdp/2021/rdp_2021-09-17.md`.
 
-### Structure type et modèle
+#### Structure type et modèle
 
 Les revues de presse sont structurées de la même façon d'une édition à l'autre, facilitant leur consultation et les traitements automatiques. Le plus simple est donc de copier/coller la structure type à partir du modèle maintenu à jour :
 
@@ -143,7 +199,7 @@ tags:
 {: align=middle }
 ```
 
-### Pousser le fichier sur GitHub
+### 3. Pousser le fichier sur GitHub
 
 Enfin, il faut pousser le fichier sur la branche créée sur GitHub.
 

--- a/content/contribuer/rdp/create_rdp.md
+++ b/content/contribuer/rdp/create_rdp.md
@@ -2,6 +2,7 @@
 title: "Créer une revue de presse"
 authors:
     - Geotribu
+    - Julien MOURA
 categories:
     - contribution
 date: "2021-09-30 10:20"
@@ -10,6 +11,9 @@ image: "https://cdn.geotribu.fr/img/articles-blog-rdp/collaboration_world.png"
 license: default
 tags:
     - contribuer
+    - GitHub
+    - GitHub Actions
+    - GitHub Workflow
     - guide
     - GeoRDP
     - workflow
@@ -19,7 +23,15 @@ tags:
 
 ![icône news générique](https://cdn.geotribu.fr/img/internal/icons-rdp-news/news.png "icône news générique"){: .img-rdp-news-thumb }
 
-La création d'une revue de presse passe par la création d'une branche dédiée dans le dépôt du site et du fichier Markdown qui contiendra les news dans une structure type. Il est possible de créer en utilisant Git en ligne de commande ou via l'interface web de GitHub.
+Concrètement, une revue de presse est un fichier markdown, nommé d'une certaine façon, stocké dans le dossier `content/rdp/` et organisé en sections dans lesquelles les contributeur/ices viennent ensuite insérer leurs "news". L processus de contribution est bâti autour de la logique de Git.
+
+Avant d'ouvrir la revue de presse aux contributions, il est donc nécessaire de créer :
+
+1. une branche dédiée dans le dépôt du site
+2. le fichier Markdown avec la structure type
+3. la Pull Request permettant de visualiser les différentes contributions puis de publier (fusionner) la revue de presse une fois finalisée
+
+Il est possible de créer en utilisant Git en ligne de commande ou via l'interface web de GitHub.
 
 !!! info "Zone réservée"
     La création d'une nouvelle revue de presse nécessite de disposer des droits d'écriture sur le dépôt GitHub : [{{ config.repo_name }}]({{ config.repo_url }}).
@@ -28,9 +40,11 @@ La création d'une revue de presse passe par la création d'une branche dédiée
 
 ![icône GitHub Actions](https://cdn.geotribu.fr/img/logos-icones/divers/github_actions.png "GitHub Actions"){: .img-rdp-news-thumb }
 
-La méthode la plus simple de créer une nouvelle revue de presse est d'utiliser le workflow *:newspaper2: New GeoRDP* disponible sur GitHub :
+L'outillage et la logique de publication de Geotribu sont largement basés sur Git et la plateforme GitHub. Nous utilisons notamment les principes de l'intégration et du déploiement continus ([CI/CD pour les intimes](https://fr.wikipedia.org/wiki/CI/CD)).
 
-1. Se rendre sur l'onglet `Actions` et sélectionner le workflow *:newspaper2: New GeoRDP* ou [cliquer ici]({{ config.repo_url }}actions/workflows/manual_new_rdp.yml)
+La méthode la plus simple pour créer une nouvelle revue de presse est donc d'utiliser le *workflow* ":newspaper2: New GeoRDP" disponible sur GitHub :
+
+1. Se rendre sur l'onglet `Actions` et sélectionner le *workflow* ":newspaper2: New GeoRDP" ou [cliquer ici]({{ config.repo_url }}actions/workflows/manual_new_rdp.yml)
 2. Cliquer sur `Run workflow`
 3. Entrer les infos demandées :
     - branche : `master`
@@ -38,12 +52,21 @@ La méthode la plus simple de créer une nouvelle revue de presse est d'utiliser
     - choisir d'envoyer automatiquement une notification sur Slack
 4. Cliquer sur le bouton vert `Run workflow`.
 
+Après une trentaine de secondes, on obtient :
+
+- une branche dédiée pour la revue de presse
+- un fichier Markdown avec la structure type et la date de publication
+- une Pull Request basée sur le modèle
+- une notification Slack pour informer l'équipe
+
 <!-- markdownlint-disable MD046 -->
 !!! abstract "Prérequis"
-    La bonne exécution du workflow dépend de ces éléments configurés au préalable sur le dépôt :
+    La bonne exécution du workflow dépend de ces éléments :
 
+    - la revue de presse ou sa branche n'ont pas déjà été créées par ailleurs
+    - le modèle de revue de presse est à jour et bien présent : `content/rdp/templates/template_rdp.md`
     - le modèle de Pull Request est bien présent : `.github/PULL_REQUEST_TEMPLATE.md`
-    - que l'URL du webhook de Slack (`SLACK_WEBHOOK_URL`) est bien configuré dans [les secrets du dépôt]({{ config.repo_url }}settings/secrets/actions) (cliquer [ici pour administrer le webhook Slack](https://api.slack.com/apps/A020C9Q93BK/incoming-webhooks/))
+    - l'URL du webhook de Slack (`SLACK_WEBHOOK_URL`) est bien configurée dans [les secrets du dépôt]({{ config.repo_url }}settings/secrets/actions) (cliquer [ici pour administrer le webhook Slack](https://api.slack.com/apps/A020C9Q93BK/incoming-webhooks/))
 <!-- markdownlint-enable MD046 -->
 
 ### Utiliser localement le script intégré localement
@@ -81,7 +104,7 @@ Voici une vidéo retraçant les étapes de création d'une revue de presse via l
 
 ## Processus détaillé
 
-Cette partie permet de comprendre chaque étape du processus de création d'une revue de presse.
+Cette partie explique chaque étape du processus de création d'une revue de presse pour comprendre ce que font les automatisations présentées au-dessus (script, GitHub Actions...).
 
 ### 1. Créer la branche de la revue de presse
 

--- a/content/contribuer/rdp/workflow.md
+++ b/content/contribuer/rdp/workflow.md
@@ -22,7 +22,7 @@ tags:
 3. Les contributions sont ouvertes :
     - soit via des commits directement sur la branche de la revue de presse
     - soit via des Pull Requests pointant sur la branche de la RDP
-4. La validation de la RDP se fait par une équipe de validation
+4. La validation de la RDP se fait par l'équipe de Geotribu
 5. Une fois validée et relue, la branche est fusionnée et la RDP publiée puis diffusée.
 
 <!-- Hyperlinks reference -->

--- a/scripts/new_rdp.sh
+++ b/scripts/new_rdp.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+set -e
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <date>"
+  echo "Example: $0 2022-01-07" >&2
+  exit 1
+fi
+
+# FUNCTIONS ----------------------------
+fn_datecheck() {
+    local format="$1" d="$2"
+    [[ "$(date "+$format" -d "$d" 2>/dev/null)" == "$d" ]]
+}
+
+# GLOBALS ------------------------------
+RDP_DATE=$1
+RDP_FOLDER_PATH="content/rdp"
+RDP_TEMPLATE_PATH="content/rdp/templates/template_rdp.md"
+
+# MAIN ---------------------------------
+
+# check if passed date is valid
+if [[ "$RDP_DATE" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+    echo -e "\e[32mFormat de date valide - check 1/2."
+else
+    echo -e "\e[31mLa date doit être du type : 'AAAA-MM-JJ' (exemple : 2022-01-07)"
+    exit 1
+fi
+
+if fn_datecheck "%F" "$RDP_DATE"; then
+    echo -e "\e[32mFormat de date valide - check 2/2."
+else
+    echo -e "\e[31mDate ou format de date invalide. La date doit être du type : 'AAAA-MM-JJ' (exemple : 2022-01-07)"
+    exit 1
+fi
+
+date_formatted=$(date -d "${RDP_DATE}" '+%F')
+
+# check if date is in the future
+if [[ "$date_formatted" > "$(date '+%F')" ]]; then
+    echo -e "\e[32mLa date est bien dans le futur."
+else
+    echo -e "\e[31mLa date de la prochaine revue de presse doit être dans le futur."
+    exit 1
+fi
+
+# check if date is a friday
+if [[ "$(date -d "${date_formatted}" '+%u')" == "5" ]]; then
+    echo -e "\e[32mLa date est bien un vendredi."
+else
+    echo -e "\e[31mLa date doit être un vendredi."
+    exit 1
+fi
+
+echo "Date de la prochaine revue de presse : $date_formatted"
+
+# check if RDP branch already exists on remote
+existed_in_remote=$(git ls-remote --heads origin rdp/"$date_formatted")
+
+if [[ -z ${existed_in_remote} ]]; then
+    echo -e "\e[32mLa branche de la prochaine RDP n'existe pas encore et sera créée."
+else
+    echo -e "\e[31mLa branche existe déjà sur le dépôt principal (GitHub).\e[33m\nPour ne pas risquer d'écraser, on bascule sur la branche distante existante et on s'arrête là."
+    git checkout --progress --track origin/rdp/"$date_formatted"
+    exit 1
+fi
+
+# determine final path
+RDP_PATH="$RDP_FOLDER_PATH/$(date -d "${date_formatted}" '+%Y')/rdp_$date_formatted.md"
+echo -e "\e[34mLe fichier de la prochaine revue de presse sera $RDP_PATH"
+
+# make sure parent folder exists
+[ -d "$RDP_PATH" ] || mkdir -p -v "$(dirname "$RDP_PATH")"
+
+# copy template
+cp -v $RDP_TEMPLATE_PATH "$RDP_PATH"
+
+# replace default values
+sed -i "s|^title:.*|title: Revue de presse du $(date -d "${date_formatted}" '+%-d %B %Y')|" "$RDP_PATH"
+sed -i "s|^date:.*|date: $(date -d "${date_formatted}" '+%Y-%m-%d') 14:20|" "$RDP_PATH"
+sed -i "s|^description:.*|description: \"\"|" "$RDP_PATH"
+sed -i "s|^# Revue de presse du.*|# Revue de presse du $(date -d "${date_formatted}" '+%-d %B %Y')|" "$RDP_PATH"
+echo -e "\e[32mValeurs par défaut remplacées."


### PR DESCRIPTION
**Objectif**

Réduire les aspects récurrents du processus de contribution sur les revues de presse. En particulier avec cette PR : la création d'une nouvelle revue de presse.

**Contenu**

- ajout d'un script qui prend la date de publication attendue
- ajout d'un workflow GitHub déclenchable manuellement depuis l'interface en lui passant des paramètres (date et option Slack) qui :
1. utilise le script avec la date passée par l'interface
2. crée et publie la branche de la RDP
3. crée la Pull Request à partir du modèle
4. notifie l'équipe sur Slack
- mise à jour du guide de contribution pour inclure ces améliorations