### PR TITLE
Ajoute un workflow de nettoyage de la prévisualisation quand une PR est fermée

### DIFF
--- a/.github/workflows/pr_cleaner_post_merge.yml
+++ b/.github/workflows/pr_cleaner_post_merge.yml
@@ -9,7 +9,7 @@ on:
 
 # Environment variables
 env:
-  BUILD_DIR: scripts/
+  BUILD_DIR: build/
   NETLIFY_SITE_NAME: geotribu-preprod
   NETLIFY_SITE_PREFIX: preview-pullrequest-${{ github.event.pull_request.number }}
 
@@ -19,6 +19,11 @@ jobs:
     steps:
       - name: Get source code
         uses: actions/checkout@v2
+
+      - name: Prepare redirection
+        run: |
+          mkdir -p ${{ env.BUILD_DIR }}
+          cp scripts/redirect.html ${{ env.BUILD_DIR }}/index.html
 
       - name: Deploy preview to Netlify
         uses: nwtgck/actions-netlify@v1.2

--- a/.github/workflows/pr_cleaner_post_merge.yml
+++ b/.github/workflows/pr_cleaner_post_merge.yml
@@ -1,0 +1,39 @@
+name: "🧹 PR Cleaner"
+
+# See: https://shipit.dev/posts/trigger-github-actions-on-pr-close.html
+
+# only trigger on pull request closed events, that includes both merged and closed (dismissed) PRs
+on:
+  pull_request:
+    types: [closed]
+
+# Environment variables
+env:
+  BUILD_DIR: scripts/
+  NETLIFY_SITE_NAME: geotribu-preprod
+  NETLIFY_SITE_PREFIX: preview-pullrequest-${{ github.event.pull_request.number }}
+
+jobs:
+  clean-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy preview to Netlify
+        uses: nwtgck/actions-netlify@v1.2
+        id: preview
+        timeout-minutes: 1
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        with:
+          alias: ${{ env.NETLIFY_SITE_PREFIX }}
+          deploy-message: "Clean preview of PR ${{ github.event.pull_request.title }} (PR #${{ env.PR_NUMBER }}"
+          enable-commit-comment: false
+          enable-commit-status: false
+          enable-pull-request-comment: false
+          fails-without-credentials: true
+          github-deployment-environment: pr-previews
+          github-deployment-description: "Preview deploy for PRs"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          overwrites-pull-request-comment: false
+          production-deploy: false
+          publish-dir: ${{ env.BUILD_DIR }}

--- a/.github/workflows/pr_cleaner_post_merge.yml
+++ b/.github/workflows/pr_cleaner_post_merge.yml
@@ -17,6 +17,9 @@ jobs:
   clean-preview:
     runs-on: ubuntu-latest
     steps:
+      - name: Get source code
+        uses: actions/checkout@v2
+
       - name: Deploy preview to Netlify
         uses: nwtgck/actions-netlify@v1.2
         id: preview

--- a/content/rdp/templates/template_rdp.md
+++ b/content/rdp/templates/template_rdp.md
@@ -19,7 +19,7 @@ tags:
 
 ## Intro
 
-![icône news générique](https://cdn.geotribu.fr/img/internal/icons-rdp-news/news.png "News"){: .img-rdp-news-thumb }
+![icône news générique](https://cdn.geotribu.fr/img/internal/icons-rdp-news/news.png "icône news générique"){: .img-rdp-news-thumb }
 
 [Commenter cette revue de presse :fontawesome-solid-comments:](#__comments){: .md-button }
 {: align=middle }

--- a/content/rdp/templates/template_rdp_news.md
+++ b/content/rdp/templates/template_rdp_news.md
@@ -1,6 +1,6 @@
 ### TITRE DE LA NEWS
 
-![icône news générique](https://cdn.geotribu.fr/img/internal/icons-rdp-news/news.png "News"){: .img-rdp-news-thumb loading=lazy }
+![icône news générique](https://cdn.geotribu.fr/img/internal/icons-rdp-news/news.png "icône news générique"){: .img-rdp-news-thumb loading=lazy }
 
 **Ou choisir une autre icône depuis le CDN : <https://cdn.geotribu.fr/img/internal/icons-rdp-news/>**
 

--- a/scripts/redirect.html
+++ b/scripts/redirect.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="fr">
+
+<head>
+    <link rel="canonical" href="https://static.geotribu.fr/">
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url='https://static.geotribu.fr/'" />
+    <meta name="robots" content="noindex">
+    <title>Redirection Geotribu</title>
+</head>
+
+<body>
+    <p>Site de prévisualisation fermé. Merci de vous rendre sur <a href="https://static.geotribu.fr/">le site
+            principal</a>.</p>
+</body>
+
+</html>


### PR DESCRIPTION
Nouveau GitHub Workflow :

1. se déclenche quand une pull request est fermée (mergée ou refusée) - [voir doc](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request)
2. pousse un simple fichier html de redirection en lieu et place du site de preview


Close #535 