### PR TITLE
Patch coquilles articles qgis dashboard

### DIFF
--- a/content/articles/2022/2022-02-11_dashboard_qgis_adresse_CD14.md
+++ b/content/articles/2022/2022-02-11_dashboard_qgis_adresse_CD14.md
@@ -48,7 +48,7 @@ En janvier 2022, le département accompagnait ainsi plus de 200 communes et avai
 Au sein du pôle SIG, nous souhaitions obtenir une vue d’ensemble des données produites au fur et à mesure de l’avancement du projet. Il fallait donc identifier une solution SIG permettant d’assurer un suivi interactif des données (contrôle des erreurs de saisies et bilan de l'avancement du projet).
 Elle devait s’intégrer au logiciel QGIS utilisé par le chargé de mission SIG du Département et sur l’application cartographique Lizmap à disposition des communes et des partenaires.
 
-Sur le logiciel QGIS aucun module additionnel (plugin) ne propose à ce jour de solution complète de dashboarding. Nous nous nous sommes donc appuyer sur une méthodologie publiée sur le site <https://plugins.QGIS.org/geopackages/5/> (Sutton, 2020) , afin de développer un « Dashboard » par manipulation des étiquettes de couches QGIS.
+Nous nous sommes appuyés sur une méthodologie publiée sur le site <https://plugins.QGIS.org/geopackages/5/> (Sutton, 2020) , afin de développer un « Dashboard » par manipulation des étiquettes de couches QGIS.
 
 Cette méthode permet, en créant une couche spécifique de tableau de bord, de paramétrer le style des étiquettes de la couche et via requêtes sql d’agrégation, de produire un tableau interactif de suivi des données présentes dans le projet QGIS.
 
@@ -159,13 +159,13 @@ Ci-dessous, nous avons organisé la table avec une fenêtre par ligne comme suit
 
 ### Exemple de requêtes utilisées
 
-1- total de la somme des valeurs de la colonne pt_total de la couche Infos Communes
+1- Total de la somme des valeurs de la colonne pt_total de la couche Infos Communes
 
 ```sql
 aggregate(layer:= 'Infos Communes', aggregate:='sum', expression:=pt_total)
 ```
 
-2- total de la somme des valeurs de la collonne pt_total des entités sélectionnées sur la couche Infos Communes
+2- Total de la somme des valeurs de la collonne pt_total des entités sélectionnées sur la couche Infos Communes
 
 ```sql
 aggregate(layer:= 'Infos Communes', aggregate:='sum', expression:=pt_total, filter:=is_selected('Infos Communes', $currentfeature )  )


### PR DESCRIPTION
<!-- Modèle pour créer une nouvelle revue de presse.

MERCI DE SUPPRIMER OU ADAPTER POUR LES AUTRES TYPES DE CONTENUS (principe du `benevol time fair-use`).

Pour les articles, voir : https://static.geotribu.fr/contribuer/articles/workflow/#soumettre

 -->

# Amorcer une nouvelle revue de presse

- [ ] nommer cette _Pull Request_ de façon claire et lisible. Exemple : `GeoRDP du JJ MM AAAA`
- [ ] partir du modèle disponible (copier/coller) [sur Github](https://github.com/geotribu/website/blob/master/content/rdp/templates/template_rdp.md?plain=1) ou [sur le pad](https://geotripad.herokuapp.com/DCBQirjYSp6sqxPd5JYqLg?both)
- [ ] changer la date dans les métadonnées :
  - [ ] `date` : au format `AAAA-MM-JJ HH-MM` - mais laisser l'heure sur 14h20 c'est historique
  - [ ] `title` : correspond à ce qui est affiché dans le menu de navigation, l'onglet du navigateur et le SEO. Bien **indiquer l'année** pour améliorer le référencement et en prévision d'une refonte du moteur de rendu.
- [ ] changer la date du titre principal (en début de contenu). Idem, **indiquer l'année**.

## Encourager les contributions

- [ ] informer l'équipe que la prochaine RDP a été initiée en publiant le lien de la PR sur [le canal `#revues-de-presse` de Slack](https://geotribu.slack.com/archives/C010DD7FMEX)
- [ ] tweeter le lien du fichier de la RDP. Voici ci-dessous un modèle dans lequel :

- remplacer `XXXXXXXXXX` par le lien vers le fichier de la GeoRDP dans la branche créée (par exemple : <https://github.com/geotribu/website/blob/rdp/2021-02-26/content/rdp/2021/rdp_2021-02-26.md?plain=1>)
- insérer cette image dans le tweet <https://cdn.geotribu.fr/img/internal/contribution/geotribu_contribuer_rdp_github_edit.png>

```txt
Ce vendredi c'est #GeoRDP !

💡 Une idée de news ? Une envie de parler de #carte ? d'outil #SIG ? de relayer un article, un tutoriel  sur la #géographie ou la #géomatique ?

C'est par ici 👉 XXXXXXXXXX 👈
(icône 🖍️)

Modèle de news ici : https://github.com/geotribu/website/blob/master/content/rdp/templates/template_rdp_news.md
```

Exemple de [tweet](https://twitter.com/geotribu/status/1364625815099613185) :

![tweet geordp](https://cdn.geotribu.fr/img/internal/contribution/geotribu_rdp_tweet_incitation.png)

----

## Check-list de publication

### Qualité

- [ ] les news sont bien réparties dans les bonnes sections
- [ ] les sections vides sont supprimées
- [ ] vérifier le rendu de la syntaxe markdown (cf. linter)
- [ ] chasse aux coquilles orthographiques et dyslexiques

### Images

- [ ] les images téléversées sur le CDN n'ont pas de caractère spécial dans leur nom de fichier (espace, accent, etc.) et n'excédent pas 1000px de largeur
- [ ] les images sont hébergées sur des sites sécurisés (HTTPS)
- [ ] chaque news a une vignette
- [ ] les images (sauf les vignettes) ont l'attribut `loading` défini sur `lazy` (cf. [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-loading) et [guide material-mkdocs](https://squidfunk.github.io/mkdocs-material/reference/images/#image-lazy-loading))
- [ ] accessibilité : chaque image a un texte de remplacement (entre les crochets) et un titre lisible par les outils d'assistance. Bref, qui respecte la [syntaxe générale](https://static.geotribu.fr/contribuer/guides/image/#syntaxe-generale)

### SEO

- [ ] `image` pointe vers l'URL d'une des images de la revue de presse
- [ ] `description` contient les mots-clés et grandes lignes du contenu (par exemple, la reprise de l'intro)

----

## Publier

1. S'assurer que la branche soit à jour par rapport à la branche principale. Le cas échéant, utiliser le bouton `Update branch` en bas.
2. S'assurer que les éléments de la check-list ci-dessus soient tous remplis
3. Fusionner (_merge_) en utilisant un _merge commit_ ou un _rebase_, mais **surtout pas un squash**.

----

## Diffuser sur Twitter

Une fois le déploiement effectué (~ 5 minutes), diffuser a minima sur Twitter :

- avec le hashtag `#GeoRDP`, en citant les contributeur/ices avec leur éventuel compte
- si possible en intégrant quelques hastags des personne, organisations ou logiciels cités dans la revue de presse
- de préférence via le compte `@geotribu` en utilisant Tweetdeck.
