### PR TITLE
Feature : renforce la confidentialité en intégrant les scripts externes pendant le build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,11 +26,6 @@ jobs:
       with:
         python-version: 3.8
 
-    - name: Set up NodeJS (for search index prebuilding)
-      uses: actions/setup-node@v2
-      with:
-        node-version: '14'
-
     - name: Cache project dependencies (pip)
       uses: actions/cache@v2
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,6 @@ jobs:
         ENABLED_GIT_AUTHORS: true
         ENABLED_GIT_REVISION_DATE: true
         MKDOCS_GOOGLE_ANALYTICS_KEY: ${{ secrets.GOOGLE_ANALYTICS_KEY }}
-        MKDOCS_SEARCH_PREBUILD_INDEX: node
 
     - name: Deploy to Github Pages
       run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         python-version: 3.9
 
-    - name: Cache project dependencies (pip)
+    - name: Cache project dependencies
       uses: actions/cache@v2
       with:
         path: ~/.cache/pip

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,10 +47,10 @@ jobs:
       run: |
         mkdocs build --clean --config-file mkdocs.yml --verbose --strict
       env:
-        ENABLED_GIT_AUTHORS: true
-        ENABLED_GIT_REVISION_DATE: true
-        ENABLED_MATERIAL_PRIVACY_PLUGIN: true
-        MKDOCS_ENABLE_RSS_PLUGIN: true
+        MKDOCS_ENABLE_PLUGIN_GIT_AUTHORS: true
+        MKDOCS_ENABLE_PLUGIN_GIT_DATES: true
+        MKDOCS_ENABLE_PLUGIN_PRIVACY: true
+        MKDOCS_ENABLE_PLUGIN_RSS: true
         MKDOCS_GOOGLE_ANALYTICS_KEY: ${{ secrets.GOOGLE_ANALYTICS_KEY }}
 
     - name: Deploy to Github Pages

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,8 @@ jobs:
       env:
         ENABLED_GIT_AUTHORS: true
         ENABLED_GIT_REVISION_DATE: true
+        ENABLED_MATERIAL_PRIVACY_PLUGIN: true
+        MKDOCS_ENABLE_RSS_PLUGIN: true
         MKDOCS_GOOGLE_ANALYTICS_KEY: ${{ secrets.GOOGLE_ANALYTICS_KEY }}
 
     - name: Deploy to Github Pages

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,10 +21,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set up Python 3.8
+    - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: Cache project dependencies (pip)
       uses: actions/cache@v2

--- a/.github/workflows/pr_checker_build.yml
+++ b/.github/workflows/pr_checker_build.yml
@@ -33,11 +33,6 @@ jobs:
         with:
           python-version: 3.8
 
-      - name: Set up NodeJS (for search index prebuilding)
-        uses: actions/setup-node@v2
-        with:
-          node-version: "14"
-
       - name: Cache project dependencies (pip)
         uses: actions/cache@v2
         with:

--- a/.github/workflows/pr_checker_build.yml
+++ b/.github/workflows/pr_checker_build.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           python-version: 3.9
 
-      - name: Cache project dependencies (pip)
+      - name: Cache project dependencies
         uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/pr_checker_build.yml
+++ b/.github/workflows/pr_checker_build.yml
@@ -28,10 +28,10 @@ jobs:
       - name: Get source code
         uses: actions/checkout@v2
 
-      - name: Set up Python 3.8
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Cache project dependencies (pip)
         uses: actions/cache@v2

--- a/.github/workflows/pr_checker_build.yml
+++ b/.github/workflows/pr_checker_build.yml
@@ -64,8 +64,7 @@ jobs:
 
       - name: Build in strict mode
         env:
-          MKDOCS_SEARCH_PREBUILD_INDEX: node
-          NETLIFY_BRANDING: '<a href="https://www.netlify.com/"><img alt="Deploys by Netlify" src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg" style="float: right;"></a>'
+            NETLIFY_BRANDING: '<a href="https://www.netlify.com/"><img alt="Deploys by Netlify" src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg" style="float: right;"></a>'
         run: |
           # site name
           sed -i "s|^site_name:.*|site_name: Geotribu PREVIEW |" ${{steps.dependencies.outputs.config_path}}

--- a/.github/workflows/pr_checker_build.yml
+++ b/.github/workflows/pr_checker_build.yml
@@ -41,7 +41,9 @@ jobs:
       - name: Cache project dependencies (pip)
         uses: actions/cache@v2
         with:
-          path: ~/.cache/pip
+          path: |
+            ~/.cache/pip
+            .cache
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,8 @@
     // Extensions
     "cSpell.language": "fr",
     "yaml.schemas": {
-        "https://squidfunk.github.io/mkdocs-material/schema.json": "mkdocs*.yml"
+        "https://squidfunk.github.io/mkdocs-material/schema.json": "mkdocs*.yml",
+        "https://json.schemastore.org/github-workflow.json": ".github/workflows/*.yml",
+        "https://json.schemastore.org/markdownlint.json": ".markdownlint*",
     }
 }

--- a/mkdocs-free.yml
+++ b/mkdocs-free.yml
@@ -94,6 +94,8 @@ plugins:
         "contribuer/workflow_article.md": "contribuer/articles/workflow.md"
         "contribuer/backup.md": "contribuer/internal/backup.md"
         "contribuer/build_site/markdown_engine.md": "contribuer/internal/markdown_engine.md"
+  - tags:
+      tags_file: tags.md
 
 # Theme
 theme:

--- a/mkdocs-free.yml
+++ b/mkdocs-free.yml
@@ -26,12 +26,12 @@ plugins:
         - "*/templates/*"
         - "*.yml"
   - git-authors:
-      enabled: !ENV [ENABLED_GIT_AUTHORS, False]
+      enabled: !ENV [MKDOCS_ENABLE_PLUGIN_GIT_AUTHORS, False]
       exclude:
         - index.md
       show_contribution: true
   - git-revision-date-localized:
-      enabled: !ENV [ENABLED_GIT_REVISION_DATE, False]
+      enabled: !ENV [MKDOCS_ENABLE_PLUGIN_GIT_DATES, False]
       enable_creation_date: true
       fallback_to_build_date: true
       locale: fr
@@ -51,7 +51,7 @@ plugins:
         as_creation: "date"
         as_update: false
         datetime_format: "%Y-%m-%d %H:%M"
-      enabled: !ENV [MKDOCS_ENABLE_RSS_PLUGIN, false]
+      enabled: !ENV [MKDOCS_ENABLE_PLUGIN_RSS, false]
       image: "https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png"
       length: 50
       match_path: "(articles|rdp)/.*"
@@ -196,6 +196,7 @@ markdown_extensions:
   - abbr
   # Admonition - https://squidfunk.github.io/mkdocs-material/extensions/admonition/
   - admonition
+  - attr_list
   # Footnotes - https://squidfunk.github.io/mkdocs-material/reference/footnotes/
   - footnotes
   # Metadata - https://squidfunk.github.io/mkdocs-material/extensions/metadata

--- a/mkdocs-free.yml
+++ b/mkdocs-free.yml
@@ -59,7 +59,8 @@ plugins:
         utm_source: "rss-feed"
         utm_medium: "RSS"
         utm_campaign: "feed-syndication"
-  - search
+  - search:
+      lang: fr
   - macros:
       include_dir: content/toc_nav_ignored/snippets
   - redirects:

--- a/mkdocs-free.yml
+++ b/mkdocs-free.yml
@@ -193,7 +193,6 @@ extra_javascript:
 # Extensions to enhance markdown - see: https://squidfunk.github.io/mkdocs-material/getting-started/#extensions
 markdown_extensions:
   - abbr
-  - attr_list
   # Admonition - https://squidfunk.github.io/mkdocs-material/extensions/admonition/
   - admonition
   # Footnotes - https://squidfunk.github.io/mkdocs-material/reference/footnotes/

--- a/mkdocs-free.yml
+++ b/mkdocs-free.yml
@@ -188,7 +188,6 @@ extra_css:
 extra_javascript:
   - "theme/assets/javascripts/extra.js"
   - "https://cdn.jsdelivr.net/npm/wa-mediabox@1.0.1/dist/wa-mediabox.min.js"
-  - "https://unpkg.com/mermaid@8.8.4/dist/mermaid.min.js"
 
 # Extensions to enhance markdown - see: https://squidfunk.github.io/mkdocs-material/getting-started/#extensions
 markdown_extensions:
@@ -220,7 +219,7 @@ markdown_extensions:
       custom_fences:
         - name: mermaid
           class: mermaid
-          format: !!python/name:pymdownx.superfences.fence_div_format
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.tasklist:

--- a/mkdocs-free.yml
+++ b/mkdocs-free.yml
@@ -51,6 +51,7 @@ plugins:
         as_creation: "date"
         as_update: false
         datetime_format: "%Y-%m-%d %H:%M"
+      enabled: !ENV [MKDOCS_ENABLE_RSS_PLUGIN, false]
       image: "https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png"
       length: 50
       match_path: "(articles|rdp)/.*"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,8 @@ plugins:
   - search
   - macros:
       include_dir: content/toc_nav_ignored/snippets
+  - privacy:
+      download: !ENV [MATERIAL_PRIVACY_PLUGIN, false]
   - redirects:
       redirect_maps:
         # RSS
@@ -196,9 +198,9 @@ extra_javascript:
 # Extensions to enhance markdown - see: https://squidfunk.github.io/mkdocs-material/getting-started/#extensions
 markdown_extensions:
   - abbr
-  - attr_list
   # Admonition - https://squidfunk.github.io/mkdocs-material/extensions/admonition/
   - admonition
+  - attr_list
   # Footnotes - https://squidfunk.github.io/mkdocs-material/reference/footnotes/
   - footnotes
   # Metadata - https://squidfunk.github.io/mkdocs-material/extensions/metadata

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,7 +59,8 @@ plugins:
         utm_source: "rss-feed"
         utm_medium: "RSS"
         utm_campaign: "feed-syndication"
-  - search
+  - search:
+      lang: fr
   - macros:
       include_dir: content/toc_nav_ignored/snippets
   - privacy:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,7 +65,7 @@ plugins:
   - macros:
       include_dir: content/toc_nav_ignored/snippets
   - privacy:
-      download: !ENV [MKDOCS_ENABLE_PLUGIN_PRIVACY, false]
+      download: !ENV [MKDOCS_ENABLE_PLUGIN_PRIVACY, true]
   - redirects:
       redirect_maps:
         # RSS

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,12 +26,12 @@ plugins:
         - "*/templates/*"
         - "*.yml"
   - git-authors:
-      enabled: !ENV [ENABLED_GIT_AUTHORS, False]
+      enabled: !ENV [MKDOCS_ENABLE_PLUGIN_GIT_AUTHORS, False]
       exclude:
         - index.md
       show_contribution: true
   - git-revision-date-localized:
-      enabled: !ENV [ENABLED_GIT_REVISION_DATE, False]
+      enabled: !ENV [MKDOCS_ENABLE_PLUGIN_GIT_DATES, False]
       enable_creation_date: true
       fallback_to_build_date: true
       locale: fr
@@ -51,7 +51,7 @@ plugins:
         as_creation: "date"
         as_update: false
         datetime_format: "%Y-%m-%d %H:%M"
-      enabled: !ENV [MKDOCS_ENABLE_RSS_PLUGIN, false]
+      enabled: !ENV [MKDOCS_ENABLE_PLUGIN_RSS, false]
       image: "https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png"
       length: 50
       match_path: "(articles|rdp)/.*"
@@ -65,7 +65,7 @@ plugins:
   - macros:
       include_dir: content/toc_nav_ignored/snippets
   - privacy:
-      download: !ENV [MATERIAL_PRIVACY_PLUGIN, false]
+      download: !ENV [MKDOCS_ENABLE_PLUGIN_PRIVACY, false]
   - redirects:
       redirect_maps:
         # RSS

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ plugins:
         as_creation: "date"
         as_update: false
         datetime_format: "%Y-%m-%d %H:%M"
+      enabled: !ENV [MKDOCS_ENABLE_RSS_PLUGIN, false]
       image: "https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png"
       length: 50
       match_path: "(articles|rdp)/.*"

--- a/requirements-insiders.txt
+++ b/requirements-insiders.txt
@@ -1,7 +1,7 @@
 # Insiders
 # --------
 
-git+https://${GH_TOKEN_MATERIAL_INSIDERS}@github.com/squidfunk/mkdocs-material-insiders.git@8.1.11-insiders-4.8.2#egg=mkdocs-material
+git+https://${GH_TOKEN_MATERIAL_INSIDERS}@github.com/squidfunk/mkdocs-material-insiders.git@8.2.1-insiders-4.9.1#egg=mkdocs-material
 # git+https://${GH_TOKEN_MATERIAL_INSIDERS}@github.com/squidfunk/mkdocs-material-insiders.git
 
 -r requirements.txt


### PR DESCRIPTION
Active le [plugin Privacy du thème Material for Insiders](https://squidfunk.github.io/mkdocs-material/setup/ensuring-data-privacy/#how-it-works) qui télécharge les scripts externes pendant le build afin de les intégrer dans le site directement, limitant ainsi les appels externes (CDN, etc.).

1 point pour la confidentialité et 1 point pour le GreenIT !

Au passage :

- passage à Python 3.9 pour la CI
- retire NodeJS des GitHub Actions depuis que la recherche n'utilise plus l'index prégénéré
- MAJ le thème Material
- active les tags et Mermaid pour les personnes n'ayant pas accès au jeton Insiders