### PR TITLE
fix/2011/2-relevelTitles-suite

### DIFF
--- a/content/rdp/2011/rdp_2011-04-01.md
+++ b/content/rdp/2011/rdp_2011-04-01.md
@@ -9,7 +9,6 @@ description: "Revue de presse du 1 avril 2011"
 tags:
     - carte de chaleur
     - GeoServer
-    -
     - MapServer
     - OpenLayers
     - OpenStreetMap

--- a/content/rdp/2011/rdp_2011-04-01.md
+++ b/content/rdp/2011/rdp_2011-04-01.md
@@ -9,6 +9,7 @@ description: "Revue de presse du 1 avril 2011"
 tags:
     - carte de chaleur
     - GeoServer
+    - 
     - MapServer
     - OpenLayers
     - OpenStreetMap
@@ -22,7 +23,7 @@ tags:
 
 Cette semaine des nouvelles de [MapServer](#mapserver) et un rapprochement avec TinyOWS et mod-geocache. Le souhait de la communauté [OSM-fr](#osm) de s'émanciper de l'OSGEO. Le développement d'OpenLayers sur mobile continue avec la possibilité de dessiner. Encore, des données ouvertes à [Barcelone](#barcelona) ou au Canada.
 
-## Vers une association OSM-fr ?
+### Vers une association OSM-fr ?
 
 ![OSM_logo.png](https://cdn.geotribu.fr/img/logos-icones/OpenStreetMap/Openstreetmap.png){: .img-rdp-news-thumb }
 

--- a/content/rdp/2011/rdp_2011-04-01.md
+++ b/content/rdp/2011/rdp_2011-04-01.md
@@ -9,7 +9,7 @@ description: "Revue de presse du 1 avril 2011"
 tags:
     - carte de chaleur
     - GeoServer
-    - 
+    -
     - MapServer
     - OpenLayers
     - OpenStreetMap

--- a/content/rdp/2011/rdp_2011-07-01.md
+++ b/content/rdp/2011/rdp_2011-07-01.md
@@ -18,7 +18,7 @@ tags:
 
 Quelques nouvelles fraîches du GeoWeb. Tout d’abord, les [sorties de la semaine](#nouveaute), mais aussi de [nouvelles fonctionnalités](#ol) pour openLayers ou encore une [réflexion intéressante](#wms) sur les services Web OGC. Bonne lecture
 
-## Bindings Java pour Mapnik
+### Bindings Java pour Mapnik
 
 ![mapnik](https://cdn.geotribu.fr/img/logos-icones/logiciels_librairies/mapnik.png){: .img-rdp-news-thumb }
 

--- a/content/rdp/2011/rdp_2011-09-02.md
+++ b/content/rdp/2011/rdp_2011-09-02.md
@@ -23,7 +23,7 @@ Bonne lecture !
 
 ![openlayers](https://cdn.geotribu.fr/img/logos-icones/logiciels_librairies/openlayers.png){: .img-rdp-news-thumb }
 
-## Calculatrice OpenLayers Raster
+### Calculatrice OpenLayers Raster
 
 Vous pensiez la librairie OpenLayers réservée principalement à l'affichage et au traitement de données vecteurs ? Tim Schaub vient de nous prouver le contraire avec une série d'exemples traitant des images. Je vous laisse admirer le travail :
 


### PR DESCRIPTION
fix : niveaux de titre des premières news de 3 rdps

Suite à remarque de @igeofr 
https://github.com/geotribu/website/pull/494#pullrequestreview-888065689