### PR TITLE
Fonctionnalité : icônes associées aux tags

### DIFF
--- a/content/rdp/2012/rdp_2012-01-20.md
+++ b/content/rdp/2012/rdp_2012-01-20.md
@@ -15,7 +15,7 @@ tags:
     - OpenLayers
     - OpenSeaMap
     - OpenStreetMap
-    - pyKML
+    - PyKML
     - R
 ---
 

--- a/content/rdp/2012/rdp_2012-04-13.md
+++ b/content/rdp/2012/rdp_2012-04-13.md
@@ -12,7 +12,7 @@ tags:
     - Mapnik
     - open data
     - OpenStreetMap
-    - pycsw
+    - PyCSW
     - Python
     - QGIS
     - whereconf

--- a/content/rdp/2015/rdp_2015-07-03.md
+++ b/content/rdp/2015/rdp_2015-07-03.md
@@ -12,7 +12,7 @@ tags:
     - art
     - Géoportail
     - GeoVIS
-    - Googe Sheep View
+    - Google Sheep View
     - Mapiful
     - Metrogit
     - radio Nova
@@ -41,7 +41,7 @@ Il est désormais possible de consulter le Géoportail dans une version spécifi
 
 ## Google
 
-### Googe Sheep View
+### Google Sheep View
 
 ![icône mouton](https://cdn.geotribu.fr/img/logos-icones/divers/sheep.png "icône mouton"){: .img-rdp-news-thumb }
 

--- a/content/rdp/2016/rdp_2016-06-24.md
+++ b/content/rdp/2016/rdp_2016-06-24.md
@@ -1,5 +1,5 @@
 ---
-title: "Revue de presse du 24 juin"
+title: "Revue de presse du 24 juin 2016"
 authors:
     - Geotribu
 categories:

--- a/content/rdp/2016/rdp_2016-06-24.md
+++ b/content/rdp/2016/rdp_2016-06-24.md
@@ -16,7 +16,7 @@ tags:
     - IGN
     - Minecraft
     - Open Solar Map
-    - pgRrouting
+    - pgRouting
     - QGIS
     - R
     - Shipmap

--- a/content/rdp/2020/rdp_2020-12-11.md
+++ b/content/rdp/2020/rdp_2020-12-11.md
@@ -17,7 +17,7 @@ tags:
     - OpenStreetMap
     - Orfeo ToolBox
     - OWSLib
-    - pycsw
+    - PyCSW
     - QGIS
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -130,10 +130,14 @@ theme:
     tag:
       default: fontawesome/solid/tag
       # -- custom tags icons
+      atlas: fontawesome/solid/book-atlas
       code: fontawesome/solid/code
       database: fontawesome/solid/database
+      facebook: fontawesome/brands/facebook
+      globe: fontawesome/solid/earth-europe
       google: fontawesome/brands/google
       js: fontawesome/brands/js
+      meridiens: fontawesome/solid/globe
       python: fontawesome/brands/python
       route: fontawesome/solid/route
       rstats: fontawesome/brands/r-project
@@ -205,19 +209,23 @@ extra:
       link: https://fr.tipeee.com/geotribu/
       name: "Le pot commun sur Tipee"
   tags:
+    atlas: atlas
     D3.js: js
     ExtJS: js
+    Facebook: facebook
     Google: google
     Google Earth: google
     Google Maps: google
     Google Street View: google
     GraphHopper: route
     JavaScript: js
+    livre: atlas
     pgDay: database
     pgRouting: route
     PGSession: database
     PostGIS: database
     PostgreSQL: database
+    projection: meridiens
     PyCSW: python
     PyGEOS: python
     PyQGIS: python
@@ -225,6 +233,7 @@ extra:
     PySQL: python
     Python: python
     PyWPS: python
+    QGIS: globe
     R: rstats
     route: route
     routing: route

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -135,6 +135,7 @@ theme:
       google: fontawesome/brands/google
       js: fontawesome/brands/js
       python: fontawesome/brands/python
+      route: fontawesome/solid/route
       rstats: fontawesome/brands/r-project
   language: fr
   logo: "https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png"
@@ -210,8 +211,10 @@ extra:
     Google Earth: google
     Google Maps: google
     Google Street View: google
+    GraphHopper: route
     JavaScript: js
     pgDay: database
+    pgRouting: route
     PGSession: database
     PostGIS: database
     PostgreSQL: database
@@ -223,6 +226,8 @@ extra:
     Python: python
     PyWPS: python
     R: rstats
+    route: route
+    routing: route
     SQL: database
 
 extra_css:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,6 +127,15 @@ theme:
   font: false
   icon:
     repo: fontawesome/brands/github-alt
+    tag:
+      default: fontawesome/solid/tag
+      # -- custom tags icons
+      code: fontawesome/solid/code
+      database: fontawesome/solid/database
+      google: fontawesome/brands/google
+      js: fontawesome/brands/js
+      python: fontawesome/brands/python
+      rstats: fontawesome/brands/r-project
   language: fr
   logo: "https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png"
   palette:
@@ -194,6 +203,27 @@ extra:
     - icon: "fontawesome/solid/piggy-bank"
       link: https://fr.tipeee.com/geotribu/
       name: "Le pot commun sur Tipee"
+  tags:
+    D3.js: js
+    ExtJS: js
+    Google: google
+    Google Earth: google
+    Google Maps: google
+    Google Street View: google
+    JavaScript: js
+    pgDay: database
+    PGSession: database
+    PostGIS: database
+    PostgreSQL: database
+    PyCSW: python
+    PyGEOS: python
+    PyQGIS: python
+    PyQt: python
+    PySQL: python
+    Python: python
+    PyWPS: python
+    R: rstats
+    SQL: database
 
 extra_css:
   - "theme/assets/stylesheets/extra.css"

--- a/requirements-insiders.txt
+++ b/requirements-insiders.txt
@@ -1,7 +1,7 @@
 # Insiders
 # --------
 
-git+https://${GH_TOKEN_MATERIAL_INSIDERS}@github.com/squidfunk/mkdocs-material-insiders.git@8.2.9-insiders-4.12.0#egg=mkdocs-material
+git+https://${GH_TOKEN_MATERIAL_INSIDERS}@github.com/squidfunk/mkdocs-material-insiders.git@8.2.11-insiders-4.13.1#egg=mkdocs-material
 # git+https://${GH_TOKEN_MATERIAL_INSIDERS}@github.com/squidfunk/mkdocs-material-insiders.git
 
 -r requirements.txt


### PR DESCRIPTION
Ajout de la nouvelle fonctionnalité Insiders : https://squidfunk.github.io/mkdocs-material/setup/setting-up-tags/#tag-icons

- icône par défaut
- ajout de quelques icônes pour commencer 
- au passage, quelques corrections de typos dans les tags

![image](https://user-images.githubusercontent.com/1596222/165081465-a383f2f3-5242-4103-837a-7f70e979e681.png)


