### PR TITLE
Automatise la consolidation d'une proposition de news faite via le formulaire GitHub

### DIFF
--- a/.github/ISSUE_TEMPLATE/RDP_NEWS.yml
+++ b/.github/ISSUE_TEMPLATE/RDP_NEWS.yml
@@ -21,7 +21,7 @@ body:
         # Vous
 
   - type: checkboxes
-    id: cb-author-content-relationship
+    id: cb_author_content_relationship
     attributes:
       label: "Avez-vous un lien avec le contenu proposé ?"
       description: Mise en avant du travail d'un tiers ? Auto-promo ? Publicité ?
@@ -32,7 +32,7 @@ body:
       required: true
 
   - type: input
-    id: in-author-name
+    id: in_author_name
     attributes:
       label: Votre nom
       description: Merci de nous indiquer le Prénom NOM (pseudonyme accepté) sous lequel vous attribuer la contribution (voir [signer ses contributions](https://static.geotribu.fr/contribuer/guides/authoring/#signer-pour-quelquun-dautre)).
@@ -41,7 +41,7 @@ body:
       required: true
 
   - type: input
-    id: in-author-mail
+    id: in_author_mail
     attributes:
       label: Votre adresse email
       description: Merci de nous indiquer votre adresse email afin de pouvoir vous attribuer la contribution (voir [signer ses contributions](https://static.geotribu.fr/contribuer/guides/authoring/#signer-pour-quelquun-dautre)).
@@ -50,7 +50,7 @@ body:
       required: true
 
   - type: checkboxes
-    id: in-author-license
+    id: in_author_license
     attributes:
       label: Licence
       description: Vous acceptez que votre contribution soit publiée sous la licence [CC BY-NC-SA 4.0](https://static.geotribu.fr/contribuer/guides/licensing/#licence-par-defaut).
@@ -65,7 +65,7 @@ body:
         # La news
 
   - type: dropdown
-    id: dr-news-category
+    id: dr_news_category
     attributes:
       label: Section / catégorie
       description: "A quelle [section ou catégorie](https://static.geotribu.fr/contribuer/rdp/add_news/#sections-categories) rattacher la news ?"
@@ -83,7 +83,7 @@ body:
       required: true
 
   - type: input
-    id: in-news-tags
+    id: in_news_tags
     attributes:
       label: Mots-clés
       description: |
@@ -93,7 +93,7 @@ body:
       required: true
 
   - type: input
-    id: in-news-title
+    id: in_news_title
     attributes:
       label: Titre de la news
       description: "Le titre accrocheur de la news. Longeur maximale indicative : 100/120 caractères"
@@ -101,7 +101,7 @@ body:
       required: true
 
   - type: input
-    id: in-news-icon
+    id: in_news_icon
     attributes:
       label: Icône de la news
       description: |
@@ -114,7 +114,7 @@ body:
       required: true
 
   - type: textarea
-    id: tx-news-content
+    id: tx_news_content
     attributes:
       label: Contenu de la news
       description: La syntaxe Markdown est acceptée, mais le rendu final diffèrera de celui de GitHub.
@@ -127,7 +127,7 @@ body:
         ----
 
   - type: textarea
-    id: tx-misc-comment
+    id: tx_misc_comment
     attributes:
       label: Message libre
       description: "Un commentaire ? Une précision à apporter ? Un message pour l'équipe ?"

--- a/.github/workflows/issue_comment.yml
+++ b/.github/workflows/issue_comment.yml
@@ -1,0 +1,71 @@
+name: "Réponse automatique à un ticket de proposition de contenu"
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+jobs:
+  rdp_form:
+    name: "📰 Proposition de news"
+    runs-on: ubuntu-latest
+    if: contains( github.event.issue.labels.*.name, 'rdp')
+
+    permissions:
+      issues: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          cache: "pip"
+          python-version: 3.9
+
+      - name: Parse template form
+        uses: stefanbuck/github-issue-parser@v2
+        id: issue-parser
+        with:
+          template-path: .github/ISSUE_TEMPLATE/RDP_NEWS.yml
+
+      - run: echo '${{ steps.issue-parser.outputs.jsonString }}' > rdp_news_submitted.json
+
+      - name: Save form artifact
+        uses: actions/upload-artifact@v3.1.0
+        with:
+          path: "rdp*.json"
+          retention-days: 15
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install -U setuptools wheel
+          python -m pip install -U jinja2
+
+      - name: Fill comment template with form
+        env:
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+          ISSUE_ID: ${{ github.event.issue.number }}
+        run: python scripts/issue_comment_templater_rdp.py
+
+      - name: Save comment artifact
+        uses: actions/upload-artifact@v3.1.0
+        with:
+          path: "rdp*_output.md"
+          retention-days: 15
+
+      - name: Load comment body from file
+        id: get-comment-body
+        run: |
+          body="$(cat rdp_news_submitted_comment_output.md)"
+          body="${body//'%'/'%25'}"
+          body="${body//$'\n'/'%0A'}"
+          body="${body//$'\r'/'%0D'}"
+          echo "::set-output name=body::$body"
+
+      - name: Create comment
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: ${{ steps.get-comment-body.outputs.body }}

--- a/scripts/issue_comment_rdp_template.jinja
+++ b/scripts/issue_comment_rdp_template.jinja
@@ -1,0 +1,38 @@
+Merci pour cette proposition de news @{{ issue_author }} !
+
+Ceci est un message automatique pour faciliter l'intégration de la news dans la revue de presse par l'équipe Geotribu.
+
+## Contenu de la news consolidé
+
+A ajouter dans l'en-tête :
+
+```yaml
+{% for tag in in_news_tags %}- {{ tag }}{% endfor %}
+```
+
+```markdown
+## {{ dr_news_category }}
+
+### {{ in_news_title }}
+
+![{{ in_icon_description }}]({{ in_news_icon }} "{{ in_icon_description }}"){: .img-rdp-news-thumb loading=lazy }
+
+{{ tx_news_content}}
+
+!!! info "Contribution externe"
+    Cette news est proposée par {{ in_author_name }} via [le formulaire GitHub renouvelé](https://github.com/geotribu/website/issues/new?assignees=Guts&labels=contribution+externe%2Crdp%2Ctriage&template=RDP_NEWS.yml) : [voir le ticket](https://github.com/geotribu/website/issues/{{ issue_id }}). Merci !
+```
+
+## Ajouter cette news à la RDP
+
+> Volet réservé à un ayant-droit de commit sur le dépôt
+
+- [ ] tenir compte de l'éventuel commentaire libre
+- [ ] téléverser l'eventuelle illustration sur le CDN et l'intégrer dans le corps du texte
+- [ ] peaufiner la description et le texte de remplacement de la vignette
+
+Commande Git pour garantir l'attribution :
+
+```sh
+git commit --author="{{ in_author_name }} <{{ in_author_mail }}>" --message="Ajout news {{ in_news_title }} par @{{ issue_author }}. Close #{{ issue_id }}"
+```

--- a/scripts/issue_comment_templater_rdp.py
+++ b/scripts/issue_comment_templater_rdp.py
@@ -20,7 +20,7 @@ data["issue_author"] = getenv("ISSUE_AUTHOR", "Inconnu(e)")
 data["issue_id"] = getenv("ISSUE_ID", "99999")
 
 # handle legacy form keys id (- not supported)
-new_keys=[k.replace("-", "_") for k in data.keys()]
+new_keys = [k.replace("-", "_") for k in data.keys()]
 data = dict(zip(new_keys, data.values()))
 
 # ensure image description and replacement text
@@ -31,7 +31,9 @@ if img_thumbnail_url.startswith("http"):
         img_thumbnail_name = img_thumbnail_path.stem
         img_description = f"vignette {img_thumbnail_name}"
     except Exception as exc:
-        logging.error(f"Failed to extract image name from URL: {img_thumbnail_url}. Trace: {exc}")
+        logging.error(
+            f"Failed to extract image name from URL: {img_thumbnail_url}. Trace: {exc}"
+        )
         img_description = "vignette news"
 else:
     img_description = data.get("in_news_icon")
@@ -52,5 +54,7 @@ env = Environment(
 template = env.get_template(issue_comment_template.name)
 
 # write to the output
-with Path("rdp_news_submitted_comment_output.md").open("w", encoding="UTF8") as out_file:
+with Path("rdp_news_submitted_comment_output.md").open(
+    "w", encoding="UTF8"
+) as out_file:
     out_file.write(template.render(data))

--- a/scripts/issue_comment_templater_rdp.py
+++ b/scripts/issue_comment_templater_rdp.py
@@ -1,0 +1,56 @@
+# standard
+import json
+import logging
+from os import getenv
+from pathlib import Path
+
+# 3rd party
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+# variables
+submitted_form_data: Path = Path("rdp_news_submitted.json")
+issue_comment_template: Path = Path("issue_comment_rdp_template.jinja")
+
+# load JSON from issue form
+with submitted_form_data.open("r", encoding="UTF8") as in_json:
+    data = json.load(in_json)
+
+# complete data with environment vars
+data["issue_author"] = getenv("ISSUE_AUTHOR", "Inconnu(e)")
+data["issue_id"] = getenv("ISSUE_ID", "99999")
+
+# handle legacy form keys id (- not supported)
+new_keys=[k.replace("-", "_") for k in data.keys()]
+data = dict(zip(new_keys, data.values()))
+
+# ensure image description and replacement text
+img_thumbnail_url = data.get("in_news_icon")
+if img_thumbnail_url.startswith("http"):
+    try:
+        img_thumbnail_path = Path(img_thumbnail_url)
+        img_thumbnail_name = img_thumbnail_path.stem
+        img_description = f"vignette {img_thumbnail_name}"
+    except Exception as exc:
+        logging.error(f"Failed to extract image name from URL: {img_thumbnail_url}. Trace: {exc}")
+        img_description = "vignette news"
+else:
+    img_description = data.get("in_news_icon")
+data["in_icon_description"] = img_description
+
+# improve tags
+if isinstance(data.get("in_news_tags"), str) and len(data.get("in_news_tags")):
+    data["in_news_tags"] = sorted(data.get("in_news_tags").split(","))
+else:
+    data["in_news_tags"] = []
+
+# fill the comment template
+env = Environment(
+    autoescape=select_autoescape(["html", "xml"]),
+    loader=FileSystemLoader(Path(__file__).parent),
+)
+
+template = env.get_template(issue_comment_template.name)
+
+# write to the output
+with Path("rdp_news_submitted_comment_output.md").open("w", encoding="UTF8") as out_file:
+    out_file.write(template.render(data))


### PR DESCRIPTION
Objectif : faire gagner du temps à l'équipe pour traiter les propositions de news soumises via le formulaire (issue) de GitHub.

Exemple de résultat :

![image](https://user-images.githubusercontent.com/1596222/188890420-35c82ad0-2360-4966-9322-de631f0c0904.png)
