### PR TITLE
Corrige le favicon manquant

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -118,7 +118,7 @@ plugins:
 theme:
   name: "material"
   custom_dir: "./content/theme/"
-  favicon: "https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png"
+  favicon: "theme/assets/images/geotribu/geotribu_logo_64x64.png"
 
   # Don't include MkDocs' JavaScript
   include_search_page: false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -118,7 +118,7 @@ plugins:
 theme:
   name: "material"
   custom_dir: "./content/theme/"
-  favicon: "theme/assets/images/geotribu/geotribu_logo_64x64.png"
+  favicon: "https://cdn.geotribu.fr/img/internal/charte/geotribu_logo_64x64.png"
 
   # Don't include MkDocs' JavaScript
   include_search_page: false

--- a/requirements-insiders.txt
+++ b/requirements-insiders.txt
@@ -1,7 +1,7 @@
 # Insiders
 # --------
 
-git+https://${GH_TOKEN_MATERIAL_INSIDERS}@github.com/squidfunk/mkdocs-material-insiders.git@8.5.10-insiders-4.26.2#egg=mkdocs-material
+git+https://${GH_TOKEN_MATERIAL_INSIDERS}@github.com/squidfunk/mkdocs-material-insiders.git@8.5.10-insiders-4.26.3#egg=mkdocs-material
 # git+https://${GH_TOKEN_MATERIAL_INSIDERS}@github.com/squidfunk/mkdocs-material-insiders.git
 
 -r requirements.txt


### PR DESCRIPTION
Actuellement, la favicon n'apparaît plus. Ticket upstream : https://github.com/squidfunk/mkdocs-material/issues/4631

~~En attendant une réponse voire une correction, on utilise une image locale.~~

La correction ayant été rapidement publié, on utilise plutôt la dernière version du thème.