### PR TITLE
Ajoute le lien vers le compte Mastodon

### DIFF
--- a/config/extra_social.yml
+++ b/config/extra_social.yml
@@ -1,0 +1,34 @@
+social:
+  - icon: "fontawesome/solid/rss"
+    link: "https://static.geotribu.fr/feed_rss_created.xml"
+    name: "S'abonner aux nouveaux contenus via RSS"
+  - icon: "fontawesome/brands/github-alt"
+    link: "https://github.com/geotribu/"
+    name: "L'organisation Github de Geotribu"
+  - icon: "fontawesome/brands/mastodon"
+    link: https://mapstodon.space/web/@geotribu
+    name: "Geotribu sur Mapstodon"
+  - icon: "fontawesome/brands/twitter"
+    link: "https://twitter.com/geotribu"
+    name: "Geotribu sur Twitter"
+  - icon: "fontawesome/brands/linkedin"
+    link: "https://www.linkedin.com/feed/hashtag/?keywords=geotribu"
+    name: "Les contenus de Geotribu sur LinkedIn"
+  - icon: "fontawesome/brands/youtube"
+    link: https://www.youtube.com/@geotribu
+    name: "Chaîne Youtube de Geotribu"
+  - icon: "fontawesome/brands/facebook"
+    link: "https://fr-fr.facebook.com/geotribu/"
+    name: "Page Facebook de Geotribu"
+  - icon: "fontawesome/brands/mailchimp"
+    link: http://eepurl.com/hL0zVr
+    name: "Abonnez-vous à la newsletter"
+  - icon: fontawesome/solid/paper-plane
+    link: mailto:<geotribu@gmail.com>
+    name: "Nous contacter"
+  - icon: "fontawesome/solid/feather-pointed"
+    link: http://pad.geotribu.fr/
+    name: "Editeur en ligne"
+  - icon: "fontawesome/solid/piggy-bank"
+    link: /team/sponsoring/
+    name: "Le pot commun sur Tipee"

--- a/content/theme/assets/stylesheets/homepage.css
+++ b/content/theme/assets/stylesheets/homepage.css
@@ -367,7 +367,7 @@
 
 @media screen and (min-width: 64rem) {
   .four-cols .g .section .component-wrapper .responsive-grid {
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(4, 1fr);
   }
 }
 

--- a/content/theme/home.html
+++ b/content/theme/home.html
@@ -215,7 +215,7 @@
       </div>
       <div class="component-wrapper" style="display: block;">
         <div class="responsive-grid">
-          <a class="card-wrapper" href="{{ config.site_url }}feed_rss_created.xml">
+          <a class="card-wrapper" href="{{ config.site_url }}feed_rss_created.xml" target="_blank">
             <div class="card">
               <div class="logo">
                 <span class="twemoji">
@@ -231,7 +231,7 @@
             </div>
           </a>
 
-          <a class="card-wrapper" href="https://plugins.qgis.org/plugins/qtribu/">
+          <a class="card-wrapper" href="https://plugins.qgis.org/plugins/qtribu/" target="_blank">
             <div class="card">
               <div class="logo">
                 <span class="twemoji">
@@ -264,7 +264,7 @@
           </a>
 
 
-          <a class="card-wrapper" href="https://twitter.com/geotribu/">
+          <a class="card-wrapper" href="https://twitter.com/geotribu/" target="_blank">
             <div class="card">
               <div class="logo">
                 <span class="twemoji">
@@ -280,7 +280,7 @@
             </div>
           </a>
 
-          <a class="card-wrapper" href="https://mapstodon.space/web/@geotribu/">
+          <a class="card-wrapper" href="https://mapstodon.space/web/@geotribu/" target="_blank">
             <div class="card">
               <div class="logo">
                 <span class="twemoji">
@@ -296,7 +296,7 @@
             </div>
           </a>
 
-          <a class="card-wrapper" href="https://www.linkedin.com/feed/hashtag/geotribu/">
+          <a class="card-wrapper" href="https://www.linkedin.com/feed/hashtag/geotribu/" target="_blank">
             <div class="card">
               <div class="logo">
                 <span class="twemoji">

--- a/content/theme/home.html
+++ b/content/theme/home.html
@@ -280,6 +280,22 @@
             </div>
           </a>
 
+          <a class="card-wrapper" href="https://mapstodon.space/web/@geotribu/">
+            <div class="card">
+              <div class="logo">
+                <span class="twemoji">
+                  {% include ".icons/fontawesome/brands/mastodon.svg" %}
+                </span>
+              </div>
+              <div class="card-content">
+                <h5>Mastodon</h5>
+                <p>
+                  Suivez le compte officiel @geotribu sur l'instance Mapstodon.
+                </p>
+              </div>
+            </div>
+          </a>
+
           <a class="card-wrapper" href="https://www.linkedin.com/feed/hashtag/geotribu/">
             <div class="card">
               <div class="logo">

--- a/mkdocs-free.yml
+++ b/mkdocs-free.yml
@@ -141,34 +141,6 @@ extra:
       des fonctionnalités (commentaires, thème clair ou sombre, etc.) et mesurer
       l'audience du site.
   manifest: "manifest.webmanifest" # PWA declaration
-  social:
-    - icon: "fontawesome/solid/rss"
-      link: "https://static.geotribu.fr/feed_rss_created.xml"
-      name: "S'abonner aux nouveaux contenus via RSS"
-    - icon: "fontawesome/brands/github-alt"
-      link: "https://github.com/geotribu/"
-      name: "L'organisation Github de Geotribu"
-    - icon: "fontawesome/brands/twitter"
-      link: "https://twitter.com/geotribu"
-      name: "Geotribu sur Twitter"
-    - icon: "fontawesome/brands/linkedin"
-      link: "https://www.linkedin.com/feed/hashtag/?keywords=geotribu"
-      name: "Les contenus de Geotribu sur LinkedIn"
-    - icon: "fontawesome/brands/facebook"
-      link: "https://fr-fr.facebook.com/geotribu/"
-      name: "Page Facebook de Geotribu"
-    - icon: "fontawesome/brands/mailchimp"
-      link: http://eepurl.com/hL0zVr
-      name: "Abonnez-vous à la newsletter"
-    - icon: fontawesome/solid/paper-plane
-      link: mailto:<geotribu@gmail.com>
-      name: "Nous contacter"
-    - icon: "fontawesome/brands/slack"
-      link: "https://geotribu.slack.com"
-      name: "Rejoignez-nous sur Slack"
-    - icon: "fontawesome/solid/feather-pointed"
-      link: http://pad.geotribu.fr/
-      name: "Editeur en ligne"
 
 extra_css:
   - "theme/assets/stylesheets/extra.css"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -179,40 +179,6 @@ extra:
       Nous utilisons des cookies pour le goûter mais aussi pour vous proposer
       des fonctionnalités (commentaires, thème clair ou sombre, etc.) et mesurer
       l'audience du site.
-  social:
-    - icon: "fontawesome/solid/rss"
-      link: "https://static.geotribu.fr/feed_rss_created.xml"
-      name: "S'abonner aux nouveaux contenus via RSS"
-    - icon: "fontawesome/brands/github-alt"
-      link: "https://github.com/geotribu/"
-      name: "L'organisation Github de Geotribu"
-    - icon: "fontawesome/brands/twitter"
-      link: "https://twitter.com/geotribu"
-      name: "Geotribu sur Twitter"
-    - icon: "fontawesome/brands/linkedin"
-      link: "https://www.linkedin.com/feed/hashtag/?keywords=geotribu"
-      name: "Les contenus de Geotribu sur LinkedIn"
-    - icon: "fontawesome/brands/youtube"
-      link: "https://www.youtube.com/channel/UCfpO6BcaqxxykBOWJzP_9jg/"
-      name: "Chaîne Youtube de Geotribu"
-    - icon: "fontawesome/brands/facebook"
-      link: "https://fr-fr.facebook.com/geotribu/"
-      name: "Page Facebook de Geotribu"
-    - icon: "fontawesome/brands/mailchimp"
-      link: http://eepurl.com/hL0zVr
-      name: "Abonnez-vous à la newsletter"
-    - icon: fontawesome/solid/paper-plane
-      link: mailto:<geotribu@gmail.com>
-      name: "Nous contacter"
-    - icon: "fontawesome/brands/slack"
-      link: "https://geotribu.slack.com"
-      name: "Rejoignez-nous sur Slack"
-    - icon: "fontawesome/solid/feather-pointed"
-      link: http://pad.geotribu.fr/
-      name: "Editeur en ligne"
-    - icon: "fontawesome/solid/piggy-bank"
-      link: https://fr.tipeee.com/geotribu/
-      name: "Le pot commun sur Tipee"
 
 extra_css:
   - "theme/assets/stylesheets/extra.css"


### PR DESCRIPTION
- ajoute le lien vers le compte Mastodon (sur l'instance Mapstodon) : page d'accueil et pied de page
- Retire le lien Slack
- MAJ le lien YouTube
- externalise les liens sociaux dans un fichier dédié (suite de https://github.com/geotribu/website/pull/699)