### PR TITLE
CI/CD : utilise Python 3.11 par défault

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
       - ".github/workflows/deploy.yml"
       - "content/**"
       - "mkdocs.yml"
-      - "requirements.txt"
+      - "requirements*.txt"
 
 jobs:
   deploy:
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.11
           cache: "pip"
 
       - name: Install dependencies

--- a/.github/workflows/issue_comment.yml
+++ b/.github/workflows/issue_comment.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           cache: "pip"
-          python-version: 3.9
+          python-version: 3.11
 
       - name: Parse template form
         uses: stefanbuck/github-issue-parser@v2

--- a/.github/workflows/pr_checker_build.yml
+++ b/.github/workflows/pr_checker_build.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.11
           cache: "pip"
 
       - name: Install dependencies

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,13 @@
     // Editor
     "editor.bracketPairColorization.enabled": true,
     "editor.guides.bracketPairs": "active",
+    "files.associations": {
+        "./requirements*.txt": "pip-requirements"
+    },
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+        "source.organizeImports": true
+    },
     // Python
     "python.pythonPath": ".venv/bin/python",
     "python.formatting.provider": "black",


### PR DESCRIPTION
Supposément plus rapide que les précédentes versions : https://www.python.org/downloads/release/python-3110/ et https://github.com/mkdocs/mkdocs/releases/tag/1.4.2