### PR TITLE
CI : Remplace les commandes dépréciées de GitHub Actions

### DIFF
--- a/.github/workflows/issue_comment.yml
+++ b/.github/workflows/issue_comment.yml
@@ -66,10 +66,10 @@ jobs:
           body="${body//'%'/'%25'}"
           body="${body//$'\n'/'%0A'}"
           body="${body//$'\r'/'%0D'}"
-          echo "body=$body" >> $GITHUB_OUTPUT
+          echo "BODY_COMMENT=$body" >> $GITHUB_OUTPUT
 
       - name: Create comment
         uses: peter-evans/create-or-update-comment@v2
         with:
           issue-number: ${{ github.event.issue.number }}
-          body: ${{ steps.get-comment-body.outputs.body }}
+          body: ${{ steps.get-comment-body.outputs.BODY_COMMENT }}

--- a/.github/workflows/issue_comment.yml
+++ b/.github/workflows/issue_comment.yml
@@ -66,7 +66,7 @@ jobs:
           body="${body//'%'/'%25'}"
           body="${body//$'\n'/'%0A'}"
           body="${body//$'\r'/'%0D'}"
-          echo "::set-output name=body::$body"
+          echo "body=$body" >> $GITHUB_OUTPUT
 
       - name: Create comment
         uses: peter-evans/create-or-update-comment@v2

--- a/.github/workflows/manual_new_rdp.yml
+++ b/.github/workflows/manual_new_rdp.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           sudo locale-gen fr_FR.UTF-8
           sudo update-locale LANG=fr_FR.UTF-8
-          echo "::set-output name=date-fr-long::$(date -d ${{ github.event.inputs.date }} '+%-d %B %Y')"
+          echo "date-fr-long=$(date -d ${{ github.event.inputs.date }} '+%-d %B %Y')" >> $GITHUB_OUTPUT
 
       - name: Get source code
         uses: actions/checkout@v3

--- a/.github/workflows/manual_new_rdp.yml
+++ b/.github/workflows/manual_new_rdp.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           sudo locale-gen fr_FR.UTF-8
           sudo update-locale LANG=fr_FR.UTF-8
-          echo "date-fr-long=$(date -d ${{ github.event.inputs.date }} '+%-d %B %Y')" >> $GITHUB_OUTPUT
+          echo "DATE_FR_LONG=$(date -d ${{ github.event.inputs.date }} '+%-d %B %Y')" >> $GITHUB_ENV
 
       - name: Get source code
         uses: actions/checkout@v3
@@ -63,7 +63,7 @@ jobs:
           source_branch: rdp/${{ github.event.inputs.date }}
           destination_branch: "master"
           pr_allow_empty: false
-          pr_title: "🗞 GeoRDP du ${{ steps.locale-fr.outputs.date-fr-long }}"
+          pr_title: "🗞 GeoRDP du ${{ env.DATE_FR_LONG }}"
           pr_template: .github/PULL_REQUEST_TEMPLATE.md
 
       - name: Notification Slack
@@ -71,7 +71,7 @@ jobs:
         uses: slackapi/slack-github-action@v1.23
         if: "${{ github.event.inputs.notify-slack == 'true' }}"
         with:
-          payload: '{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":newspaper: La GeoRDP du ${{ steps.locale-fr.outputs.date-fr-long }} a été créée et attend vos contributions :writing_hand: !"}},{"type":"section","fields":[{"type":"mrkdwn","text":"Créée par *${{ github.actor }}* via GitHub Action."}]},{"type":"actions","elements":[{"type":"button","text":{"type":"plain_text","emoji":true,"text":":squid: Voir la PR (GitHub)"},"url":"${{ steps.cpr.outputs.pr_url }}"},{"type":"button","text":{"type":"plain_text","emoji":true,"text":":eye: Voir la preview (Netlify)"},"style":"primary","url":"https://preview-pullrequest-${{steps.cpr.outputs.pr_number}}--geotribu-preprod.netlify.app/"}]}]}'
+          payload: '{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":newspaper: La GeoRDP du ${{ env.DATE_FR_LONG }} a été créée et attend vos contributions :writing_hand: !"}},{"type":"section","fields":[{"type":"mrkdwn","text":"Créée par *${{ github.actor }}* via GitHub Action."}]},{"type":"actions","elements":[{"type":"button","text":{"type":"plain_text","emoji":true,"text":":squid: Voir la PR (GitHub)"},"url":"${{ steps.cpr.outputs.pr_url }}"},{"type":"button","text":{"type":"plain_text","emoji":true,"text":":eye: Voir la preview (Netlify)"},"style":"primary","url":"https://preview-pullrequest-${{steps.cpr.outputs.pr_number}}--geotribu-preprod.netlify.app/"}]}]}'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/pr_checker_build.yml
+++ b/.github/workflows/pr_checker_build.yml
@@ -46,11 +46,11 @@ jobs:
           if [[ -z "${GH_TOKEN_MATERIAL_INSIDERS}" ]]; then
             echo "::warning:: L'accès aux token est réservé aux comptes avec droits d'écriture sur le dépôt. La version gratuite du thème est donc utilisée sans mots-clés, etc.)"
             python -m pip install -U -r requirements-free.txt
-            echo "::set-output name=config_path::mkdocs-free.yml"
+            echo "{config_path}={mkdocs-free.yml}" >> $GITHUB_OUTPUT
           else
             # install insiders version using token
             python -m pip install -U -r requirements-insiders.txt
-            echo "::set-output name=config_path::mkdocs.yml"
+            echo "{config_path}={mkdocs.yml}" >> $GITHUB_OUTPUT
           fi
 
       - name: Cache build dependencies (external assets downloaded)

--- a/.github/workflows/pr_checker_build.yml
+++ b/.github/workflows/pr_checker_build.yml
@@ -46,11 +46,11 @@ jobs:
           if [[ -z "${GH_TOKEN_MATERIAL_INSIDERS}" ]]; then
             echo "::warning:: L'accès aux token est réservé aux comptes avec droits d'écriture sur le dépôt. La version gratuite du thème est donc utilisée sans mots-clés, etc.)"
             python -m pip install -U -r requirements-free.txt
-            echo "config_path=mkdocs-free.yml" >> $GITHUB_ENV
+            echo "MKDOCS_CONFIG_FILENAME=mkdocs-free.yml" >> $GITHUB_ENV
           else
             # install insiders version using token
             python -m pip install -U -r requirements-insiders.txt
-            echo "config_path=mkdocs.yml" >> $GITHUB_ENV
+            echo "MKDOCS_CONFIG_FILENAME=mkdocs.yml" >> $GITHUB_ENV
           fi
 
       - name: Cache build dependencies (external assets downloaded)
@@ -64,28 +64,28 @@ jobs:
           NETLIFY_BRANDING: '<a href="https://www.netlify.com/"><img alt="Deploys by Netlify" src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg" style="float: right;"></a>'
         run: |
           # site name
-          sed -i "s|^site_name:.*|site_name: Geotribu PREVIEW |" ${{ env.config_path }}
+          sed -i "s|^site_name:.*|site_name: Geotribu PREVIEW |" ${{ env.MKDOCS_CONFIG_FILENAME }}
 
-          # Adjust ${{steps.dependencies.outputs.config_path}} for preview build
-          sed -i "s|^site_url:.*|site_url: https://${NETLIFY_SITE_PREFIX}--${NETLIFY_SITE_NAME}.netlify.app/ |" ${{ env.config_path }}
+          # Adjust ${{ env.MKDOCS_CONFIG_FILENAME }} for preview build
+          sed -i "s|^site_url:.*|site_url: https://${NETLIFY_SITE_PREFIX}--${NETLIFY_SITE_NAME}.netlify.app/ |" ${{ env.MKDOCS_CONFIG_FILENAME }}
 
           # Insert sponsor branding into page content (Provider OSS plan requirement):
           # Upstream does not provide a nicer maintainable way to do this..
           # Prepends HTML to copyright text and then aligns to the right side.
-          sed -i "s|^copyright: '|copyright: '${NETLIFY_BRANDING}|" ${{ env.config_path }}
+          sed -i "s|^copyright: '|copyright: '${NETLIFY_BRANDING}|" ${{ env.MKDOCS_CONFIG_FILENAME }}
 
           # set repo and branch
-          sed -i "s|^repo_url:.*|repo_url: https://github.com/$GITHUB_REPOSITORY |" ${{ env.config_path }}
-          sed -i "s|^edit_uri:.*|edit_uri: edit/$GITHUB_HEAD_REF/content |" ${{ env.config_path }}
+          sed -i "s|^repo_url:.*|repo_url: https://github.com/$GITHUB_REPOSITORY |" ${{ env.MKDOCS_CONFIG_FILENAME }}
+          sed -i "s|^edit_uri:.*|edit_uri: edit/$GITHUB_HEAD_REF/content |" ${{ env.MKDOCS_CONFIG_FILENAME }}
 
           # merge different configs
-          python scripts/mkdocs_config_merger.py -c ${{ env.config_path }}
+          python scripts/mkdocs_config_merger.py -c ${{ env.MKDOCS_CONFIG_FILENAME }}
 
           # build
-          mkdocs build --config-file ${{ env.config_path }} --verbose --strict
+          mkdocs build --config-file ${{ env.MKDOCS_CONFIG_FILENAME }} --verbose --strict
 
           # save mkdocs.yml for debug
-          cp ${{ env.config_path }} ${{ env.BUILD_DIR }}
+          cp ${{ env.MKDOCS_CONFIG_FILENAME }} ${{ env.BUILD_DIR }}
 
           # remove files reserved for production
           rm ${{ env.BUILD_DIR }}/CNAME

--- a/.github/workflows/pr_checker_build.yml
+++ b/.github/workflows/pr_checker_build.yml
@@ -46,11 +46,11 @@ jobs:
           if [[ -z "${GH_TOKEN_MATERIAL_INSIDERS}" ]]; then
             echo "::warning:: L'accès aux token est réservé aux comptes avec droits d'écriture sur le dépôt. La version gratuite du thème est donc utilisée sans mots-clés, etc.)"
             python -m pip install -U -r requirements-free.txt
-            echo "{config_path}={mkdocs-free.yml}" >> $GITHUB_OUTPUT
+            echo "config_path=mkdocs-free.yml" >> $GITHUB_ENV
           else
             # install insiders version using token
             python -m pip install -U -r requirements-insiders.txt
-            echo "{config_path}={mkdocs.yml}" >> $GITHUB_OUTPUT
+            echo "config_path=mkdocs.yml" >> $GITHUB_ENV
           fi
 
       - name: Cache build dependencies (external assets downloaded)
@@ -64,28 +64,28 @@ jobs:
           NETLIFY_BRANDING: '<a href="https://www.netlify.com/"><img alt="Deploys by Netlify" src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg" style="float: right;"></a>'
         run: |
           # site name
-          sed -i "s|^site_name:.*|site_name: Geotribu PREVIEW |" ${{steps.dependencies.outputs.config_path}}
+          sed -i "s|^site_name:.*|site_name: Geotribu PREVIEW |" ${{ env.config_path }}
 
           # Adjust ${{steps.dependencies.outputs.config_path}} for preview build
-          sed -i "s|^site_url:.*|site_url: https://${NETLIFY_SITE_PREFIX}--${NETLIFY_SITE_NAME}.netlify.app/ |" ${{steps.dependencies.outputs.config_path}}
+          sed -i "s|^site_url:.*|site_url: https://${NETLIFY_SITE_PREFIX}--${NETLIFY_SITE_NAME}.netlify.app/ |" ${{ env.config_path }}
 
           # Insert sponsor branding into page content (Provider OSS plan requirement):
           # Upstream does not provide a nicer maintainable way to do this..
           # Prepends HTML to copyright text and then aligns to the right side.
-          sed -i "s|^copyright: '|copyright: '${NETLIFY_BRANDING}|" ${{steps.dependencies.outputs.config_path}}
+          sed -i "s|^copyright: '|copyright: '${NETLIFY_BRANDING}|" ${{ env.config_path }}
 
           # set repo and branch
-          sed -i "s|^repo_url:.*|repo_url: https://github.com/$GITHUB_REPOSITORY |" ${{steps.dependencies.outputs.config_path}}
-          sed -i "s|^edit_uri:.*|edit_uri: edit/$GITHUB_HEAD_REF/content |" ${{steps.dependencies.outputs.config_path}}
+          sed -i "s|^repo_url:.*|repo_url: https://github.com/$GITHUB_REPOSITORY |" ${{ env.config_path }}
+          sed -i "s|^edit_uri:.*|edit_uri: edit/$GITHUB_HEAD_REF/content |" ${{ env.config_path }}
 
           # merge different configs
-          python scripts/mkdocs_config_merger.py -c ${{steps.dependencies.outputs.config_path}}
+          python scripts/mkdocs_config_merger.py -c ${{ env.config_path }}
 
           # build
-          mkdocs build --config-file ${{steps.dependencies.outputs.config_path}} --verbose --strict
+          mkdocs build --config-file ${{ env.config_path }} --verbose --strict
 
           # save mkdocs.yml for debug
-          cp ${{steps.dependencies.outputs.config_path}} ${{ env.BUILD_DIR }}
+          cp ${{ env.config_path }} ${{ env.BUILD_DIR }}
 
           # remove files reserved for production
           rm ${{ env.BUILD_DIR }}/CNAME


### PR DESCRIPTION
Dépréciées depuis le 11 novembre et retirées en mai 2023, mais autant anticiper !

Référence : https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/