### PR TITLE
Extrait enrichi : corrige guillemets/apostrophe

### DIFF
--- a/content/articles/2009/2009-01-14_openlayers-pouvoir-realiser-un-padding-dans-une-infobulle.md
+++ b/content/articles/2009/2009-01-14_openlayers-pouvoir-realiser-un-padding-dans-une-infobulle.md
@@ -1,11 +1,11 @@
 ---
-title: 'OpenLayers, pouvoir réaliser un "padding" dans une infobulle'
+title: "OpenLayers, pouvoir réaliser un 'padding' dans une infobulle"
 authors:
     - Arnaud Vandecasteele
 categories:
     - article
 date: 2009-01-14 10:20
-description: 'OpenLayers, pouvoir réaliser un "padding" dans une infobulle'
+description: "OpenLayers, pouvoir réaliser un 'padding' dans une infobulle"
 tags:
     - infobulle
     - padding


### PR DESCRIPTION
Erreur remontée par Google :

![image](https://user-images.githubusercontent.com/1596222/203002905-33353de0-2c00-4869-b8fe-c5f28ce2b64d.png)

Pour info @igeofr : si besoin de guillemets dans un titre ou une description, utiliser les _simple quotes_ (nos apostrophes) et garder les _double quotes_ pour encadrer la chaine de caractères.
