### PR TITLE
Fonctionnalité : ajoute un widget de feedback en bas des contenus

### DIFF
--- a/.github/workflows/pr_checker_build.yml
+++ b/.github/workflows/pr_checker_build.yml
@@ -61,7 +61,6 @@ jobs:
 
       - name: Build in strict mode
         env:
-          MKDOCS_GOOGLE_ANALYTICS_KEY: ${{ secrets.GOOGLE_ANALYTICS_KEY }}
           NETLIFY_BRANDING: '<a href="https://www.netlify.com/"><img alt="Deploys by Netlify" src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg" style="float: right;"></a>'
         run: |
           # site name

--- a/.github/workflows/pr_checker_build.yml
+++ b/.github/workflows/pr_checker_build.yml
@@ -61,6 +61,7 @@ jobs:
 
       - name: Build in strict mode
         env:
+          MKDOCS_GOOGLE_ANALYTICS_KEY: ${{ secrets.GOOGLE_ANALYTICS_KEY }}
           NETLIFY_BRANDING: '<a href="https://www.netlify.com/"><img alt="Deploys by Netlify" src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg" style="float: right;"></a>'
         run: |
           # site name

--- a/config/extra_analytics.yml
+++ b/config/extra_analytics.yml
@@ -8,17 +8,17 @@ analytics:
         name: "Sympa."
         data: 0
         note: >-
-          Merci d'avoir pris le temps de faire ce retour.
-          N'hésitez pas à contribuer vous-même aux contenus de Geotribu !
+          Merci pour ce retour &#128578;.
+          Contribuer <a href="/contribuer/rdp/add_news/" target="_blank" rel="noopener">revues de presse</a>, aux <a href="/contribuer/articles/workflow/" target="_blank" rel="noopener">articles</a> ou <a href="/team/sponsoring/" target="_blank" rel="noopener">nous soutenir</a> est également facile !
       - icon: material/heart-outline
         name: "Vraiment cool !"
         data: 1
         note: >-
-          Merci pour ce retour positif !
-          Prenez donc le temps de laisser un commentaire ou de partager le contenu !
+          Merci pour ce retour &#x1F600;.
+          Contribuer <a href="/contribuer/rdp/add_news/" target="_blank" rel="noopener">revues de presse</a>, aux <a href="/contribuer/articles/workflow/" target="_blank" rel="noopener">articles</a> ou <a href="/team/sponsoring/" target="_blank" rel="noopener">nous soutenir</a> est également facile !
       - icon: material/heart-multiple-outline
         name: "Génial, ça m'a beaucoup aidé !"
         data: 2
         note: >-
-          Merci pour ce retour enthousiaste !
-          Pour pérenniser ce genre de contenus, <a href="/team/sponsoring/" target="_blank" rel="noopener">pensez à nous soutenir</a> !
+          Merci pour ce retour &#128522; !
+          Contribuer <a href="/contribuer/rdp/add_news/" target="_blank" rel="noopener">revues de presse</a>, aux <a href="/contribuer/articles/workflow/" target="_blank" rel="noopener">articles</a> ou <a href="/team/sponsoring/" target="_blank" rel="noopener">nous soutenir</a> est également facile !

--- a/config/extra_analytics.yml
+++ b/config/extra_analytics.yml
@@ -8,17 +8,17 @@ analytics:
         name: "Sympa."
         data: 0
         note: >-
-          Merci pour ce retour &#128578;.
-          Contribuer aux <a href="/contribuer/rdp/add_news/" target="_blank" rel="noopener">revues de presse</a>, aux <a href="/contribuer/articles/workflow/" target="_blank" rel="noopener">articles</a> ou <a href="/team/sponsoring/" target="_blank" rel="noopener">nous soutenir</a> est également facile !
+          Merci pour ce retour &#128578;.<br/>
+          Contribuer aux <a href="/contribuer/rdp/add_news/" target="_blank" rel="noopener">revues de presse</a>, aux <a href="/contribuer/articles/workflow/" target="_blank" rel="noopener">articles</a> ou <a href="/team/sponsoring/" target="_blank" rel="noopener">nous soutenir</a>, rien de plus simple !
       - icon: material/heart-outline
         name: "Vraiment cool !"
         data: 1
         note: >-
-          Merci pour ce retour &#x1F600;.
-          Contribuer aux <a href="/contribuer/rdp/add_news/" target="_blank" rel="noopener">revues de presse</a>, aux <a href="/contribuer/articles/workflow/" target="_blank" rel="noopener">articles</a> ou <a href="/team/sponsoring/" target="_blank" rel="noopener">nous soutenir</a> est également facile !
+          Merci pour ce retour &#x1F600;.<br/>
+          Contribuer aux <a href="/contribuer/rdp/add_news/" target="_blank" rel="noopener">revues de presse</a>, aux <a href="/contribuer/articles/workflow/" target="_blank" rel="noopener">articles</a> ou <a href="/team/sponsoring/" target="_blank" rel="noopener">nous soutenir</a>, rien de plus simple !
       - icon: material/heart-multiple-outline
         name: "Génial, ça m'a beaucoup aidé !"
         data: 2
         note: >-
           Merci pour ce retour &#128522; !<br/>
-          Contribuer aux <a href="/contribuer/rdp/add_news/" target="_blank" rel="noopener">revues de presse</a>, aux <a href="/contribuer/articles/workflow/" target="_blank" rel="noopener">articles</a> ou <a href="/team/sponsoring/" target="_blank" rel="noopener">nous soutenir</a> est également facile !
+          Contribuer aux <a href="/contribuer/rdp/add_news/" target="_blank" rel="noopener">revues de presse</a>, aux <a href="/contribuer/articles/workflow/" target="_blank" rel="noopener">articles</a> ou <a href="/team/sponsoring/" target="_blank" rel="noopener">nous soutenir</a>, rien de plus simple !

--- a/config/extra_analytics.yml
+++ b/config/extra_analytics.yml
@@ -21,4 +21,4 @@ analytics:
         data: 2
         note: >-
           Merci pour ce retour enthousiaste !
-          Pour pérenniser ce genre de contenus, <a href="https://static.geotribu.fr/team/sponsoring/" target="_blank" rel="noopener">pensez à nous soutenir</a> !
+          Pour pérenniser ce genre de contenus, <a href="/team/sponsoring/" target="_blank" rel="noopener">pensez à nous soutenir</a> !

--- a/config/extra_analytics.yml
+++ b/config/extra_analytics.yml
@@ -9,16 +9,16 @@ analytics:
         data: 0
         note: >-
           Merci pour ce retour &#128578;.
-          Contribuer <a href="/contribuer/rdp/add_news/" target="_blank" rel="noopener">revues de presse</a>, aux <a href="/contribuer/articles/workflow/" target="_blank" rel="noopener">articles</a> ou <a href="/team/sponsoring/" target="_blank" rel="noopener">nous soutenir</a> est également facile !
+          Contribuer aux <a href="/contribuer/rdp/add_news/" target="_blank" rel="noopener">revues de presse</a>, aux <a href="/contribuer/articles/workflow/" target="_blank" rel="noopener">articles</a> ou <a href="/team/sponsoring/" target="_blank" rel="noopener">nous soutenir</a> est également facile !
       - icon: material/heart-outline
         name: "Vraiment cool !"
         data: 1
         note: >-
           Merci pour ce retour &#x1F600;.
-          Contribuer <a href="/contribuer/rdp/add_news/" target="_blank" rel="noopener">revues de presse</a>, aux <a href="/contribuer/articles/workflow/" target="_blank" rel="noopener">articles</a> ou <a href="/team/sponsoring/" target="_blank" rel="noopener">nous soutenir</a> est également facile !
+          Contribuer aux <a href="/contribuer/rdp/add_news/" target="_blank" rel="noopener">revues de presse</a>, aux <a href="/contribuer/articles/workflow/" target="_blank" rel="noopener">articles</a> ou <a href="/team/sponsoring/" target="_blank" rel="noopener">nous soutenir</a> est également facile !
       - icon: material/heart-multiple-outline
         name: "Génial, ça m'a beaucoup aidé !"
         data: 2
         note: >-
-          Merci pour ce retour &#128522; !
-          Contribuer <a href="/contribuer/rdp/add_news/" target="_blank" rel="noopener">revues de presse</a>, aux <a href="/contribuer/articles/workflow/" target="_blank" rel="noopener">articles</a> ou <a href="/team/sponsoring/" target="_blank" rel="noopener">nous soutenir</a> est également facile !
+          Merci pour ce retour &#128522; !<br/>
+          Contribuer aux <a href="/contribuer/rdp/add_news/" target="_blank" rel="noopener">revues de presse</a>, aux <a href="/contribuer/articles/workflow/" target="_blank" rel="noopener">articles</a> ou <a href="/team/sponsoring/" target="_blank" rel="noopener">nous soutenir</a> est également facile !

--- a/config/extra_analytics.yml
+++ b/config/extra_analytics.yml
@@ -4,20 +4,21 @@ analytics:
   feedback:
     title: Comment avez-vous trouvé ce contenu ?
     ratings:
+      - icon: material/heart-half-outline
+        name: "Sympa."
+        data: 0
+        note: >-
+          Merci d'avoir pris le temps de faire ce retour.
+          N'hésitez pas à contribuer vous-même aux contenus de Geotribu !
+      - icon: material/heart-outline
+        name: "Vraiment cool !"
+        data: 1
+        note: >-
+          Merci pour ce retour positif !
+          Prenez donc le temps de laisser un commentaire ou de partager le contenu !
       - icon: material/heart-multiple-outline
         name: "Génial, ça m'a beaucoup aidé !"
         data: 2
         note: >-
           Merci pour ce retour enthousiaste !
-          Pour pérenniser ce genre de contenus, <a href="{{ config.site_url }}/team/sponsoring/" target="_blank" rel="noopener">pensez à nous soutenir</a> !
-      - icon: material/heart-outline
-        name: "Vraiment cool !"
-        data: 1
-        note: >-
-          Thanks for your feedback!
-      - icon: material/heart-half-outline
-        name: "Sympa !"
-        data: 0
-        note: >-
-          Thanks for your feedback! Help us improve this page by
-          using our <a href="..." target="_blank" rel="noopener">feedback form</a>.
+          Pour pérenniser ce genre de contenus, <a href="https://static.geotribu.fr/team/sponsoring/" target="_blank" rel="noopener">pensez à nous soutenir</a> !

--- a/config/extra_analytics.yml
+++ b/config/extra_analytics.yml
@@ -1,0 +1,17 @@
+analytics:
+  provider: google
+  property: !ENV MKDOCS_GOOGLE_ANALYTICS_KEY
+  feedback:
+    title: Vous avez apprécié ce contenu ?
+    ratings:
+      - icon: material/emoticon-happy-outline
+        name: This page was helpful
+        data: 1
+        note: >-
+          Thanks for your feedback!
+      - icon: material/emoticon-sad-outline
+        name: This page could be improved
+        data: 0
+        note: >-
+          Thanks for your feedback! Help us improve this page by
+          using our <a href="..." target="_blank" rel="noopener">feedback form</a>.

--- a/config/extra_analytics.yml
+++ b/config/extra_analytics.yml
@@ -2,15 +2,21 @@ analytics:
   provider: google
   property: !ENV MKDOCS_GOOGLE_ANALYTICS_KEY
   feedback:
-    title: Vous avez apprécié ce contenu ?
+    title: Comment avez-vous trouvé ce contenu ?
     ratings:
-      - icon: material/emoticon-happy-outline
-        name: This page was helpful
+      - icon: material/heart-multiple-outline
+        name: "Génial, ça m'a beaucoup aidé !"
+        data: 2
+        note: >-
+          Merci pour ce retour enthousiaste !
+          Pour pérenniser ce genre de contenus, <a href="{{ config.site_url }}/team/sponsoring/" target="_blank" rel="noopener">pensez à nous soutenir</a> !
+      - icon: material/heart-outline
+        name: "Vraiment cool !"
         data: 1
         note: >-
           Thanks for your feedback!
-      - icon: material/emoticon-sad-outline
-        name: This page could be improved
+      - icon: material/heart-half-outline
+        name: "Sympa !"
         data: 0
         note: >-
           Thanks for your feedback! Help us improve this page by

--- a/mkdocs-free.yml
+++ b/mkdocs-free.yml
@@ -130,9 +130,6 @@ theme:
 
 # Customization
 extra:
-  analytics:
-    provider: google
-    property: !ENV MKDOCS_GOOGLE_ANALYTICS_KEY
   comments_url: https://comments.geotribu.fr # isso url
   consent:
     title: Consentement 🍪

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -170,9 +170,6 @@ theme:
 
 # Customization
 extra:
-  analytics:
-    provider: google
-    property: !ENV MKDOCS_GOOGLE_ANALYTICS_KEY
   comments_url: https://comments.geotribu.fr # isso url
   consent:
     title: Consentement 🍪

--- a/scripts/mkdocs_config_merger.py
+++ b/scripts/mkdocs_config_merger.py
@@ -62,7 +62,7 @@ with output_config_file.open(mode="r", encoding="UTF8") as in_yaml:
 for cfg_file in configs_to_merge:
     dest_section = cfg_file.stem.split("_")[0]
     with cfg_file.open(mode="r") as part_config:
-        cfg_data = yaml.safe_load(part_config)
+        cfg_data = yaml_load(part_config)
 
     out_section = config_to_complete.get(dest_section)
     if isinstance(out_section, list):


### PR DESCRIPTION
Ajout d'un widget permettant de donner un feedback en bas de chaque contenu.  
Je propose :

- 3 niveaux
- seulement positifs (pas envie d'avoir des grincheux)
- un message différent selon quel niveau a été actionné

## Définition des niveaux

| Niveau | Icône | Message |
| :----: | :---: | :------ |
| 0 | demi-coeur vide | Merci d'avoir pris le temps de faire ce retour. N'hésitez pas à contribuer vous-même aux contenus de Geotribu |
| 1 | coeur entier vide | Merci pour ce retour positif ! Prenez donc le temps de laisser un commentaire ou de partager le contenu ! |
| 2 | deux coeurs entiers vides | Merci pour ce retour enthousiaste ! Pour pérenniser ce genre de contenus, <a href="/team/sponsoring/" target="_blank" rel="noopener>pensez à nous soutenir</a> ! |

Les icônes sont à hoisir parmi celles du thème : https://squidfunk.github.io/mkdocs-material/reference/#setting-the-page-icon  
A moins que quelqu'un se motive pour en créer des spécifiques pour Geotribu.

## Exemple de rendu

![Screenshot_20221201-230358_Firefox.jpg](https://user-images.githubusercontent.com/1596222/205171007-16fc7911-9a2b-42b1-8ca8-418475cf303d.jpg)

![Screenshot_20221201-230406_Firefox.jpg](https://user-images.githubusercontent.com/1596222/205171054-00f33e4f-e4d5-4501-a38d-68e874d0e5ca.jpg)

![Screenshot_20221201-230423_Firefox.jpg](https://user-images.githubusercontent.com/1596222/205171080-23d700e1-f0ef-4e6c-8bac-70775111e365.jpg)

![Screenshot_20221201-230434_Firefox.jpg](https://user-images.githubusercontent.com/1596222/205170990-a4cf5123-0a03-4c4e-9763-fd1689c1d977.jpg)