### PR TITLE
Recherche : applique un boost aux contenus les plus récents

### DIFF
--- a/content/articles/2008/.meta.yml
+++ b/content/articles/2008/.meta.yml
@@ -1,0 +1,2 @@
+search:
+  boost: 8

--- a/content/articles/2009/.meta.yml
+++ b/content/articles/2009/.meta.yml
@@ -1,0 +1,2 @@
+search:
+  boost: 9

--- a/content/articles/2010/.meta.yml
+++ b/content/articles/2010/.meta.yml
@@ -1,0 +1,2 @@
+search:
+  boost: 10

--- a/content/articles/2011/.meta.yml
+++ b/content/articles/2011/.meta.yml
@@ -1,0 +1,2 @@
+search:
+  boost: 11

--- a/content/articles/2012/.meta.yml
+++ b/content/articles/2012/.meta.yml
@@ -1,0 +1,2 @@
+search:
+  boost: 12

--- a/content/articles/2013/.meta.yml
+++ b/content/articles/2013/.meta.yml
@@ -1,0 +1,2 @@
+search:
+  boost: 13

--- a/content/articles/2014/.meta.yml
+++ b/content/articles/2014/.meta.yml
@@ -1,0 +1,2 @@
+search:
+  boost: 14

--- a/content/articles/2015/.meta.yml
+++ b/content/articles/2015/.meta.yml
@@ -1,0 +1,2 @@
+search:
+  boost: 15

--- a/content/articles/2020/.meta.yml
+++ b/content/articles/2020/.meta.yml
@@ -1,0 +1,2 @@
+search:
+  boost: 20

--- a/content/articles/2021/.meta.yml
+++ b/content/articles/2021/.meta.yml
@@ -1,0 +1,2 @@
+search:
+  boost: 21

--- a/content/articles/2022/.meta.yml
+++ b/content/articles/2022/.meta.yml
@@ -1,0 +1,2 @@
+search:
+  boost: 22

--- a/content/articles/2023/.meta.yml
+++ b/content/articles/2023/.meta.yml
@@ -1,0 +1,2 @@
+search:
+  boost: 23

--- a/content/rdp/2010/.meta.yml
+++ b/content/rdp/2010/.meta.yml
@@ -1,0 +1,2 @@
+search:
+  boost: 10

--- a/content/rdp/2011/.meta.yml
+++ b/content/rdp/2011/.meta.yml
@@ -1,0 +1,2 @@
+search:
+  boost: 11

--- a/content/rdp/2012/.meta.yml
+++ b/content/rdp/2012/.meta.yml
@@ -1,0 +1,2 @@
+search:
+  boost: 12

--- a/content/rdp/2013/.meta.yml
+++ b/content/rdp/2013/.meta.yml
@@ -1,0 +1,2 @@
+search:
+  boost: 10

--- a/content/rdp/2014/.meta.yml
+++ b/content/rdp/2014/.meta.yml
@@ -1,0 +1,2 @@
+search:
+  boost: 10

--- a/content/rdp/2015/.meta.yml
+++ b/content/rdp/2015/.meta.yml
@@ -1,0 +1,2 @@
+search:
+  boost: 10

--- a/content/rdp/2016/.meta.yml
+++ b/content/rdp/2016/.meta.yml
@@ -1,0 +1,2 @@
+search:
+  boost: 10

--- a/content/rdp/2017/.meta.yml
+++ b/content/rdp/2017/.meta.yml
@@ -1,0 +1,2 @@
+search:
+  boost: 10

--- a/content/rdp/2020/.meta.yml
+++ b/content/rdp/2020/.meta.yml
@@ -1,0 +1,2 @@
+search:
+  boost: 10

--- a/content/rdp/2021/.meta.yml
+++ b/content/rdp/2021/.meta.yml
@@ -1,0 +1,2 @@
+search:
+  boost: 10

--- a/content/rdp/2022/.meta.yml
+++ b/content/rdp/2022/.meta.yml
@@ -1,0 +1,2 @@
+search:
+  boost: 10

--- a/content/rdp/2023/.meta.yml
+++ b/content/rdp/2023/.meta.yml
@@ -1,0 +1,2 @@
+search:
+  boost: 23


### PR DESCRIPTION
En travaillant sur la [CLI Geotribu](https://cli.geotribu.fr/), je me suis penché plus sérieusement sur la façon dont l'indextion et la recherche fonctionnent.

Cette PR permet de booster (remonter) les contenus selon leur année de publication en tirant parti de deux fonctionnalités :

- les capacités de [lunr sur le boost de documents](https://lunr.readthedocs.io/en/latest/indices.html#document-boosts)
- celles du thème qui permet d'appliquer des paramètres à des dossiers entiers via des fichiers `.meta.yml` via [le plugin meta pour les Insiders](https://squidfunk.github.io/mkdocs-material/reference/#built-in-meta-plugin)

L'idée est de favoriser les contenus les plus récents car l'historique pèse parfois (trop) lourd à mon avis dans les résultats. 

## Comparaisons de résultats avant - après

### `gdal`

Avant :

![image](https://user-images.githubusercontent.com/1596222/210166986-0e7f1dcb-6f5f-4e2b-9392-6d1bc3d2fec0.png)

Après :

![image](https://user-images.githubusercontent.com/1596222/210167063-674b0b49-74b7-4842-a373-f1a50ca152a1.png)

### `postgis`

Avant :

![image](https://user-images.githubusercontent.com/1596222/210167079-eae7c38a-8d70-4fd8-8447-9a00161ef636.png)


Après :


![image](https://user-images.githubusercontent.com/1596222/210167086-5c4e9ea6-37bc-4f47-8656-ab19365548f4.png)

### `OpenStreetMap`

Avant :

![image](https://user-images.githubusercontent.com/1596222/210167149-505da7e7-ab42-4b87-9706-b76919a67987.png)

Après :

![image](https://user-images.githubusercontent.com/1596222/210167156-0a29f02f-69a6-4bd3-b0b2-d2a6deee4f79.png)

