### PR TITLE
Met à jour le thème Material vers la version majeure 9

### DIFF
--- a/content/theme/main.html
+++ b/content/theme/main.html
@@ -198,18 +198,6 @@
 {% block content %}
 {{ super() }}
 
-{# Authoring based on git log #}
-{# note: commenté car plus utilisé depuis l'intégration des avatrs GitHub en bas de page
-{% if git_page_authors %}
-<div class="md-source-date">
-  <small>
-    Contributions à cette page : {{ git_page_authors }}
-  </small>
-</div>
-{% endif %}
-#}
-
-
 {# License #}
 {% if not page.is_homepage and ("license" not in page.meta or page.meta.license == "default") %}
 <hr>
@@ -233,32 +221,6 @@
       </a>
     </p>
   </small>
-</div>
-{% endif %}
-
-<!-- Get setting from mkdocs.yml, but allow page-level overrides -->
-{% set comments = config.extra.comments_url %}
-{% if page and page.meta and page.meta.disqus is string %}
-{% set comments = page.meta.disqus %}
-{% endif %}
-
-{% if not page.is_homepage and comments %}
-{# Comment system (Isso) #}
-<div id="__comments">
-  <script data-isso="{{ config.extra.comments_url }}/" data-isso-feed="true" data-isso-reply-notifications="true"
-    data-isso-reply-to-self="false" data-isso-require-author="true" data-isso-require-email="true" data-isso-vote="true"
-    src="{{ config.extra.comments_url }}/js/embed.min.js">
-    </script>
-  <hr>
-  <section id="isso-thread">
-    <h2>Commentaires</h2>
-    <small>
-      Une version minimale de la <a href="/contribuer/guides/markdown_basics/" hreflang="fr" target="_blank">syntaxe
-        markdown</a> est
-      acceptée pour la mise en forme des commentaires.<br>Propulsé par <a href="https://posativ.org/isso/" hreflang="en"
-        target="_blank">Isso</a>. </small>
-  </section>
-  <noscript>Please enable JavaScript to view the comments.</noscript>
 </div>
 {% endif %}
 {% endblock %}

--- a/content/theme/partials/comments.html
+++ b/content/theme/partials/comments.html
@@ -1,0 +1,17 @@
+{% if page.meta.comments %}
+<h2 id="__comments">{{ lang.t("meta.comments") }}</h2>
+<script data-isso="{{ config.extra.comments_url }}/" data-isso-feed="true" data-isso-reply-notifications="true"
+    data-isso-reply-to-self="false" data-isso-require-author="true" data-isso-require-email="true" data-isso-vote="true"
+    src="{{ config.extra.comments_url }}/js/embed.min.js">
+    </script>
+<hr>
+<section id="isso-thread">
+    <h2>Commentaires</h2>
+    <small>
+        Une version minimale de la <a href="/contribuer/guides/markdown_basics/" hreflang="fr" target="_blank">syntaxe
+            markdown</a> est
+        acceptée pour la mise en forme des commentaires.<br>Propulsé par <a href="https://posativ.org/isso/"
+            hreflang="en" target="_blank">Isso</a>. </small>
+</section>
+<noscript>Please enable JavaScript to view the comments.</noscript>
+{% endif %}

--- a/mkdocs-free.yml
+++ b/mkdocs-free.yml
@@ -82,7 +82,6 @@ plugins:
   - macros:
       include_dir: content/toc_nav_ignored/snippets
   - tags:
-      enabled: !ENV [MKDOCS_ENABLE_PLUGIN_TAGS, true]
       tags_file: tags.md
 
 # Theme
@@ -96,6 +95,9 @@ theme:
   search_index_only: true
 
   features:
+    - content.action.edit
+    - content.code.annotate
+    - content.code.copy
     - content.tabs.link
     - navigation.tabs
     - navigation.top

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -135,7 +135,9 @@ theme:
   search_index_only: true
 
   features:
+    - content.action.edit
     - content.code.annotate
+    - content.code.copy
     - content.tabs.link
     - navigation.prune
     - navigation.tabs

--- a/requirements-free.txt
+++ b/requirements-free.txt
@@ -1,6 +1,6 @@
 # No Material Insiders
 # --------------------
 
-mkdocs-material>=8.5,<8.6
+mkdocs-material>=9,<10
 
 -r requirements.txt

--- a/requirements-insiders.txt
+++ b/requirements-insiders.txt
@@ -1,7 +1,7 @@
 # Insiders
 # --------
 
-git+https://${GH_TOKEN_MATERIAL_INSIDERS}@github.com/squidfunk/mkdocs-material-insiders.git@8.5.11-insiders-4.27.0#egg=mkdocs-material
+git+https://${GH_TOKEN_MATERIAL_INSIDERS}@github.com/squidfunk/mkdocs-material-insiders.git@9.0.5-insiders-4.28.0#egg=mkdocs-material
 # git+https://${GH_TOKEN_MATERIAL_INSIDERS}@github.com/squidfunk/mkdocs-material-insiders.git
 
 mkdocs-git-committers-plugin-2>=1,<2


### PR DESCRIPTION
Voir : https://squidfunk.github.io/mkdocs-material/upgrade/#upgrading-from-8x-to-9x

Mise à jour des configurations en conséquence : commentaires, etc.