### PR TITLE
Exclue la nouvelle URL du CDN de Twemoji

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,6 +112,7 @@ plugins:
         - i.imgur.com/*
         - raw.githubusercontent.com/*
         - sondekla.com/buid/widget/*
+        - cdnjs.cloudflare.com/ajax/libs/twemoji/
         - twemoji.maxcdn.com/*
         - upload.wikimedia.org/*
         - user-images.githubusercontent.com/**/*.gif


### PR DESCRIPTION
Pour retrouver un temps de déploiement décent