### PR TITLE
Corrige le chemin du hook mkdocs dans la configuration free

### DIFF
--- a/mkdocs-free.yml
+++ b/mkdocs-free.yml
@@ -20,7 +20,7 @@ site_dir: "./build/mkdocs/site"
 
 # Scripts pendant le build
 hooks:
-  - hooks/mkdocs/check_hyperlinks.py
+  - hooks/mkdocs/G001_check_hyperlinks_internal.py
 
 # Plugins
 plugins:


### PR DESCRIPTION
Repéré par @ndavid dans #835 mais je le corrige ici car ça impacte probablement d'autres PRs qui doivent etre mergées avant.