### PR TITLE
Skippe les jobs nécessitant un token avec droits d'écriture quand une…

### DIFF
--- a/.github/workflows/pr_linter_markdown.yml
+++ b/.github/workflows/pr_linter_markdown.yml
@@ -11,6 +11,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  statuses: write
 
 jobs:
   lint-markdown-review:
@@ -35,7 +36,7 @@ jobs:
       - name: "Explications sur les erreurs du linter"
         id: pr-comment-error-create
         uses: marocchino/sticky-pull-request-comment@v2
-        if: ${{ failure() && steps.markdownlint-github-pr-review-added.conclusion == 'failure' }}
+        if: ${{ failure() && steps.markdownlint-github-pr-review-added.conclusion == 'failure' && github.event.pull_request.head.repo.fork == false }}
         with:
           header: linter-md-error
           recreate: true
@@ -50,7 +51,7 @@ jobs:
       - name: "Marque le commentaire de félicitations comme résolu"
         id: pr-comment-good-solve
         uses: marocchino/sticky-pull-request-comment@v2
-        if: ${{ success() }}
+        if: ${{ success() && github.event.pull_request.head.repo.fork == false }}
         with:
           header: linter-md-success
           hide: true
@@ -72,7 +73,7 @@ jobs:
       - name: "Marque le commentaire d'erreur comme résolu"
         id: pr-comment-error-solve
         uses: marocchino/sticky-pull-request-comment@v2
-        if: ${{ success() }}
+        if: ${{ success() && github.event.pull_request.head.repo.fork == false }}
         with:
           header: linter-md-error
           hide: true
@@ -81,7 +82,7 @@ jobs:
       - name: "Félicitations"
         id: pr-comment-good
         uses: marocchino/sticky-pull-request-comment@v2
-        if: ${{ success() }}
+        if: ${{ success() && github.event.pull_request.head.repo.fork == false }}
         with:
           header: linter-md-success
           recreate: true


### PR DESCRIPTION
Problème : quand une PR est créée depuis un fork, il est impossible de donner accès à un token avec les droits d'écriture sur la PR (même en le spécifiant).

Du coup, tous les jobs de commentaires remontent une erreur dès lors qu'il y a une contribution externe et c'est désagréable pour les contributeur/ices.

Cette PR ajoute une condition qui skip ces jobs quand la PR est issue d'un fork.