### PR TITLE
CI/CD : rend le déploiement plus paramétrable (env vars) et moderne (GH Actions)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,17 @@ env:
   LC_ALL: "fr_FR.UTF-8"
   LC_TIME: "fr_FR.UTF-8"
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
 jobs:
   deploy:
     name: "📤 GitHub Pages"
@@ -42,7 +53,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install --upgrade -r requirements-insiders.txt
-          python -m pip install --upgrade ghp-import
 
       - name: Cache build dependencies (external assets downloaded)
         uses: actions/cache@v3
@@ -63,8 +73,15 @@ jobs:
           MKDOCS_ENABLE_PLUGIN_RSS: true
           MKDOCS_GOOGLE_ANALYTICS_KEY: ${{ secrets.GOOGLE_ANALYTICS_KEY }}
 
-      - name: Deploy to Github Pages
-        run: |
-          git config --global user.name "Geotribu (Github Action)"
-          git config --global user.email "geotribu@gmail.com"
-          ghp-import --force --message="Site Geotribu déployé" --no-jekyll --no-history --push build/mkdocs/site
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          # Upload entire repository
+          path: "build/mkdocs/site"
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/content/articles/2020/2020-12-30_deployer_geotribu_a_la_maison.md
+++ b/content/articles/2020/2020-12-30_deployer_geotribu_a_la_maison.md
@@ -21,6 +21,9 @@ tags:
 
 Pré-requis : une connexion internet.
 
+!!! info "Trop tard !"
+    La méthode présentée ici ne fonctionne plus depuis cette [PR de mai 2023](https://github.com/geotribu/website/pull/923) qui a basculé le déploiement du site sur les GitHub Pages hors de la branche `gh-pages`.
+
 ## Intro
 
 ![icône matière](https://cdn.geotribu.fr/img/internal/icons-rdp-news/matiere.png "matière"){: .img-rdp-news-thumb }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,7 +97,9 @@ plugins:
       tags_file: tags.md
       tags_compare: !!python/name:material.plugins.tags.plugin.casefold
   - privacy:
-      enabled: !ENV [MKDOCS_ENABLE_PLUGIN_PRIVACY, false]
+      enabled: !ENV [MKDOCS_ENABLE_PLUGIN_PRIVACY, true]
+      external_assets_dir:
+        !ENV [MKDOCS_PLUGIN_PRIVACY_EXTERNAL_ASSETS_DIR, assets/external]
       links_attr_map:
         target: _blank
       assets_exclude:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,7 +104,7 @@ plugins:
   - privacy:
       enabled: !ENV [MKDOCS_ENABLE_PLUGIN_PRIVACY, true]
       external_assets_dir:
-        !ENV [MKDOCS_PLUGIN_PRIVACY_EXTERNAL_ASSETS_DIR, .cache/plugin/privacy]
+        !ENV [MKDOCS_PLUGIN_PRIVACY_EXTERNAL_CACHE_DIR, .cache/plugin/privacy]
       links_attr_map:
         target: _blank
       assets_exclude:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -103,7 +103,7 @@ plugins:
       tags_compare: !!python/name:material.plugins.tags.plugin.casefold
   - privacy:
       enabled: !ENV [MKDOCS_ENABLE_PLUGIN_PRIVACY, true]
-      external_assets_dir:
+      assets_fetch_dir:
         !ENV [MKDOCS_PLUGIN_PRIVACY_EXTERNAL_CACHE_DIR, .cache/plugin/privacy]
       links_attr_map:
         target: _blank

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,11 @@ plugins:
       repository: geotribu/website
       branch: master
       docs_path: content/
+      cache_dir:
+        !ENV [
+          MKDOCS_PLUGIN_GIT_COMMITTERS_CACHE_DIR,
+          .cache/plugin/git-committers/,
+        ]
   - git-revision-date-localized:
       enabled: !ENV [MKDOCS_ENABLE_PLUGIN_GIT_DATES, false]
       enable_creation_date: true
@@ -99,7 +104,7 @@ plugins:
   - privacy:
       enabled: !ENV [MKDOCS_ENABLE_PLUGIN_PRIVACY, true]
       external_assets_dir:
-        !ENV [MKDOCS_PLUGIN_PRIVACY_EXTERNAL_ASSETS_DIR, assets/external]
+        !ENV [MKDOCS_PLUGIN_PRIVACY_EXTERNAL_ASSETS_DIR, .cache/plugin/privacy]
       links_attr_map:
         target: _blank
       assets_exclude:


### PR DESCRIPTION
- rend certaines options paramétrables comme les chemins où sont stockés les caches de certains plugins
- bascule la logique de déploiement sur les GitHub Pages en utilisant GH Actions plutôt que la branche gh-pages
- ajoute un warning sur l'article https://static.geotribu.fr/articles/2020/2020-12-30_deployer_geotribu_a_la_maison/ dont la méthode est rendue caduque par cette PR