### PR TITLE
fix Tile38 link, typo, add streets.gl link

### DIFF
--- a/content/rdp/2023/rdp_2023-05-12.md
+++ b/content/rdp/2023/rdp_2023-05-12.md
@@ -61,7 +61,7 @@ Bonne lecture.
 
 ![logo tile38](https://cdn.geotribu.fr/img/logos-icones/logiciels_librairies/tile38.webp "logo tile38"){: .img-rdp-news-thumb }
 
-J’ai eu beau cherché dans les archives de GeoTribu, je n’ai rien trouvé sur ce projet opensource pourtant âgé de plusieurs années qui se nomme [Tile38](https://tile38.com). C’est un outil dédié au [géorepérage ou gardiennage virtuel](https://fr.wikipedia.org/wiki/Géorepérage) qui est capacité de stocker, d’indexer et d’analyser rapidement des données de géolocalisation en temps réel. Ce type de solution est notamment utilisé pour suivre des objets ou des animaux.
+J’ai eu beau cherché dans les archives de GeoTribu, je n’ai rien trouvé sur ce projet opensource pourtant âgé de plusieurs années qui se nomme [Tile38](https://tile38.com). C’est un outil dédié au [géorepérage ou gardiennage virtuel](https://fr.wikipedia.org/wiki/G%C3%A9orep%C3%A9rage) qui est en capacité de stocker, d’indexer et d’analyser rapidement des données de géolocalisation en temps réel. Ce type de solution est notamment utilisé pour suivre des objets ou des animaux.
 
 ![Tile38](https://cdn.geotribu.fr/img/articles-blog-rdp/logiciels/Tile38/tile38_roaming.gif){: .img-center loading=lazy }
 
@@ -95,7 +95,7 @@ Je vous laisse avec la vidéo de la société Geonov qqui revient sur les diffé
 
 ![Logo OpenStreetMap](https://cdn.geotribu.fr/img/logos-icones/OpenStreetMap/Openstreetmap.png "logo OpenStreetMap"){: .img-rdp-news-thumb }
 
-Je découvre le projet Streets GL, une web map qui propose de se balader dans les données OSM projetées en 3D en croisant données d'élevation (API Mapbox) et requêtes ciblées à l'API Overpass. L'interface est soignée et permet des réglages assez fins sur les paramèters d'affichage.
+Je découvre le projet [Streets GL](https://Street.gl), une web map qui propose de se balader dans les données OSM projetées en 3D en croisant données d'élevation (API Mapbox) et requêtes ciblées à l'API Overpass. L'interface est soignée et permet des réglages assez fins sur les paramèters d'affichage.
 
 Mais le plus marquant dans ce projet c'est qu'en parcourant [le GitHub](https://github.com/StrandedKitty/streets-gl), on s'aperçoit que l'auteur n'utilise quasiment aucune bibliothèque connue (three.js, potree, mapbog, maplibre, giro3D...) pour parvenir à ses fins mais a développé ses propres modules ! Il en va ainsi pour l'accès bas niveau à l'API WebGL 2 mais aussi d'un render/frame graph simple mais taillé à façon !
 


### PR DESCRIPTION
Salut les géotribuns, 
Bravo et merci pour la GéoRDP. Voilà 3 propositions de corrections/modifs après une rapide relecture:
- Les accents dans le lien de géorepérage étaient mal convertis tels quel;
- ajout de "en" qui manquait;
- je me suis permis d'ajouter un lien vers streets.gl car il ne m'a pas semble en voir un. Ou bien c'était intentionnel? Ou bien il y en avait un? Ou D, la réponse D?