### PR TITLE
Retire les balises RSS personnalisées

### DIFF
--- a/content/theme/main.html
+++ b/content/theme/main.html
@@ -10,12 +10,6 @@
 <meta property="robots" content="index, follow" />
 {% endif %}
 
-{# RSS Feed #}
-<link rel="alternate" type="application/rss+xml" title="RSS feed of created content"
-  href="{{ config.site_url }}feed_rss_created.xml">
-<link rel="alternate" type="application/rss+xml" title="RSS feed of updated content"
-  href="{{ config.site_url }}feed_rss_updated.xml">
-
 {# Meta title #}
 {% set title = config.site_name %}
 {% if page and page.meta and page.meta.title %}


### PR DESCRIPTION
Car elles sont désormais gérées nativement par le thème. 

Cf : https://squidfunk.github.io/mkdocs-material/setup/setting-up-a-blog/#rss

> Material for MkDocs will automatically add the [necessary metadata](https://guts.github.io/mkdocs-rss-plugin/configuration/#integration) to your site which will make the RSS feed discoverable by browsers and feed readers. Note that the [RSS plugin](https://guts.github.io/mkdocs-rss-plugin/) comes with several other configuration options. For further information, see the [documentation](https://guts.github.io/mkdocs-rss-plugin/configuration/).