### PR TITLE
Personnalisations du thème : déplace le bloc des licences dans un fichier dédié et ajoute les licences manquantes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,8 @@
     "editor.guides.bracketPairs": "active",
     "files.associations": {
         "./requirements*.txt": "pip-requirements",
-        ".linkcheckrrc": "ini"
+        ".linkcheckrrc": "ini",
+        "*.html": "jinja"
     },
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {

--- a/content/team/confidentialite.md
+++ b/content/team/confidentialite.md
@@ -100,6 +100,8 @@ Néanmoins, les commentaires sont publics et certaines données sont enregistré
 - le site web (optionnel) renseigné
 - l'adresse IP lors de la soumission du formulaire
 
+Afin de favoriser les échanges constructifs, merci de préférer le [pseudonymat](https://fr.wikipedia.org/wiki/Pseudonymat) à l'anonymat, en renseignant a minima une de vos adresses emails valable.
+
 [Consulter l'article sur la migration vers Isso](/articles/2021/2021-05-14_commentaires_migration_disqus_isso/){: .md-button }
 {: align=middle }
 

--- a/content/theme/main.html
+++ b/content/theme/main.html
@@ -192,29 +192,5 @@
 {% block content %}
 {{ super() }}
 
-{# License #}
-{% if not page.is_homepage and ("license" not in page.meta or page.meta.license == "default") %}
-<hr>
-<div class="md-source-date">
-  <small>
-    <p xmlns:cc="http://creativecommons.org/ns#">
-      Ce contenu est sous licence Creative Commons
-      <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/deed.fr" target="_blank"
-        rel="license noopener noreferrer">BY-NC-SA 4.0 International
-        <img src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" class=img-license-picto
-          alt="Pictogramme Creative Commons" longdesc="https://creativecommons.org/licenses/?lang=fr-FR" title="CC" />
-        <img src="https://mirrors.creativecommons.org/presskit/icons/by.svg" class=img-license-picto
-          alt="Pictogramme Creative Commons BY" longdesc="https://creativecommons.org/licenses/?lang=fr-FR"
-          title="BY" />
-        <img src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" class=img-license-picto
-          alt="Pictogramme Creative Commons NC" longdesc="https://creativecommons.org/licenses/?lang=fr-FR"
-          title="NC" />
-        <img src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" class=img-license-picto
-          alt="Pictogramme Creative Commons SA" longdesc="https://creativecommons.org/licenses/?lang=fr-FR"
-          title="SA" />
-      </a>
-    </p>
-  </small>
-</div>
-{% endif %}
+{% include "partials/license.html" %}
 {% endblock %}

--- a/content/theme/partials/comments.html
+++ b/content/theme/partials/comments.html
@@ -6,6 +6,8 @@
 <hr>
 <section id="isso-thread">
     <small>
+        Afin de favoriser les échanges constructifs, merci de préférer le <a href="https://fr.wikipedia.org/wiki/Pseudonymat" hreflang="fr" target="_blank" title="Page Wikipédia détaillant le pseudonymat"><b>pseudonymat</b></a> à l'anonymat. Pour rappel, l'adresse mail n'est pas exposée publiquement. Consulter la <a href="{{ config.site_url }}team/confidentialite/#commentaires" target="_blank">page sur la confidentialité et les données personnelles</a>.
+        <br>
         Une version minimale de la <a
             href="https://docs.framasoft.org/fr/grav/markdown.html"
             hreflang="fr"
@@ -18,5 +20,5 @@
         Propulsé par <a href="https://posativ.org/isso/" hreflang="en" target="_blank">Isso</a>.
     </small>
 </section>
-<noscript>Please enable JavaScript to view the comments.</noscript>
+<noscript>Merci d'activer JavaScript pour voir les commentaires.</noscript>
 {% endif %}

--- a/content/theme/partials/comments.html
+++ b/content/theme/partials/comments.html
@@ -6,10 +6,17 @@
 <hr>
 <section id="isso-thread">
     <small>
-        Une version minimale de la <a href="/contribuer/guides/markdown_basics/" hreflang="fr" target="_blank">syntaxe
-            markdown</a> est
-        acceptée pour la mise en forme des commentaires.<br>Propulsé par <a href="https://posativ.org/isso/"
-            hreflang="en" target="_blank">Isso</a>. </small>
+        Une version minimale de la <a
+            href="https://docs.framasoft.org/fr/grav/markdown.html"
+            hreflang="fr"
+            target="_blank"
+            >
+            syntaxe markdown
+            </a>
+        est acceptée pour la mise en forme des commentaires.
+        <br>
+        Propulsé par <a href="https://posativ.org/isso/" hreflang="en" target="_blank">Isso</a>.
+    </small>
 </section>
 <noscript>Please enable JavaScript to view the comments.</noscript>
 {% endif %}

--- a/content/theme/partials/license.html
+++ b/content/theme/partials/license.html
@@ -1,0 +1,60 @@
+{# License #}
+{% if not page.is_homepage %}
+<hr>
+{% if ("license" not in page.meta or page.meta.license == "default" or page.meta.license == "cc4_by-nc-sa") %}
+<div class="md-source-date">
+  <small>
+    <p xmlns:cc="http://creativecommons.org/ns#">
+      Ce contenu est sous licence Creative Commons
+      <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/deed.fr" target="_blank"
+        rel="license noopener noreferrer">BY-NC-SA 4.0 International
+        <img src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" class=img-license-picto
+          alt="Pictogramme Creative Commons" longdesc="https://creativecommons.org/licenses/?lang=fr-FR" title="CC" />
+        <img src="https://mirrors.creativecommons.org/presskit/icons/by.svg" class=img-license-picto
+          alt="Pictogramme Creative Commons BY" longdesc="https://creativecommons.org/licenses/?lang=fr-FR"
+          title="BY" />
+        <img src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" class=img-license-picto
+          alt="Pictogramme Creative Commons NC" longdesc="https://creativecommons.org/licenses/?lang=fr-FR"
+          title="NC" />
+        <img src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" class=img-license-picto
+          alt="Pictogramme Creative Commons SA" longdesc="https://creativecommons.org/licenses/?lang=fr-FR"
+          title="SA" />
+      </a>
+    </p>
+  </small>
+</div>
+<hr>
+{% elif page.meta.license == "cc4_by-sa" %}
+<div class="md-source-date">
+  <small>
+    <p xmlns:cc="http://creativecommons.org/ns#">
+      Ce contenu est sous licence Creative Commons
+      <a href="https://creativecommons.org/licenses/by-sa/4.0/deed.fr" target="_blank"
+        rel="license noopener noreferrer">BY-SA 4.0 International
+        <img src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" class=img-license-picto
+          alt="Pictogramme Creative Commons" longdesc="https://creativecommons.org/licenses/?lang=fr-FR" title="CC" />
+        <img src="https://mirrors.creativecommons.org/presskit/icons/by.svg" class=img-license-picto
+          alt="Pictogramme Creative Commons BY" longdesc="https://creativecommons.org/licenses/?lang=fr-FR"
+          title="BY" />
+        <img src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" class=img-license-picto
+          alt="Pictogramme Creative Commons SA" longdesc="https://creativecommons.org/licenses/?lang=fr-FR"
+          title="SA" />
+      </a>
+    </p>
+  </small>
+</div>
+{% elif page.meta.license == "beerware" %}
+<div class="md-source-date"></div>
+<small>
+  <p xmlns:cc="https://fr.wikipedia.org/wiki/Beerware">
+    Ce contenu est sous licence
+    <a href="https://fr.wikipedia.org/wiki/Beerware" target="_blank" rel="license noopener noreferrer"
+      title="Licence très permissive qui confère à l'utilisateur final le droit d'utiliser le contenu, sans conditions sauf paternité. Si l'utilisateur rencontre l'auteur, il est encouragé à lui offrir une bière ou autre en retour.">Beerware
+      <img src="https://upload.wikimedia.org/wikipedia/commons/d/d5/BeerWare_Logo.svg" class=img-license-picto
+        alt="Pictogramme BeerWare" longdesc="Kita59, CC BY-SA 3.0, via Wikimedia Commons" title="Beerware" />
+    </a>
+  </p>
+</small>
+</div>
+{% endif %}
+{% endif %}

--- a/content/theme/partials/license.html
+++ b/content/theme/partials/license.html
@@ -1,60 +1,59 @@
 {# License #}
 {% if not page.is_homepage %}
-<hr>
-{% if ("license" not in page.meta or page.meta.license == "default" or page.meta.license == "cc4_by-nc-sa") %}
-<div class="md-source-date">
+  <hr>
+  {% if ("license" not in page.meta or page.meta.license == "default" or page.meta.license == "cc4_by-nc-sa") %}
+  <div class="md-source-date">
+    <small>
+      <p xmlns:cc="http://creativecommons.org/ns#">
+        Ce contenu est sous licence Creative Commons
+        <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/deed.fr" target="_blank"
+          rel="license noopener noreferrer">BY-NC-SA 4.0 International
+          <img src="https://cdn.geotribu.fr/img/internal/licences/cc.svg" class=img-license-picto
+            alt="Pictogramme Creative Commons" longdesc="https://creativecommons.org/licenses/?lang=fr-FR" title="CC" />
+          <img src="https://cdn.geotribu.fr/img/internal/licences/by.svg" class=img-license-picto
+            alt="Pictogramme Creative Commons BY" longdesc="https://creativecommons.org/licenses/?lang=fr-FR"
+            title="BY" />
+          <img src="https://cdn.geotribu.fr/img/internal/licences/nc.svg" class=img-license-picto
+            alt="Pictogramme Creative Commons NC" longdesc="https://creativecommons.org/licenses/?lang=fr-FR"
+            title="NC" />
+          <img src="https://cdn.geotribu.fr/img/internal/licences/sa.svg" class=img-license-picto
+            alt="Pictogramme Creative Commons SA" longdesc="https://creativecommons.org/licenses/?lang=fr-FR"
+            title="SA" />
+        </a>
+      </p>
+    </small>
+  </div>
+  {% elif page.meta.license == "cc4_by-sa" %}
+  <div class="md-source-date">
+    <small>
+      <p xmlns:cc="http://creativecommons.org/ns#">
+        Ce contenu est sous licence Creative Commons
+        <a href="https://creativecommons.org/licenses/by-sa/4.0/deed.fr" target="_blank"
+          rel="license noopener noreferrer">BY-SA 4.0 International
+          <img src="https://cdn.geotribu.fr/img/internal/licences/cc.svg" class=img-license-picto
+            alt="Pictogramme Creative Commons" longdesc="https://creativecommons.org/licenses/?lang=fr-FR" title="CC" />
+          <img src="https://cdn.geotribu.fr/img/internal/licences/by.svg" class=img-license-picto
+            alt="Pictogramme Creative Commons BY" longdesc="https://creativecommons.org/licenses/?lang=fr-FR"
+            title="BY" />
+          <img src="https://cdn.geotribu.fr/img/internal/licences/sa.svg" class=img-license-picto
+            alt="Pictogramme Creative Commons SA" longdesc="https://creativecommons.org/licenses/?lang=fr-FR"
+            title="SA" />
+        </a>
+      </p>
+    </small>
+  </div>
+  {% elif page.meta.license == "beerware" %}
+  <div class="md-source-date"></div>
   <small>
-    <p xmlns:cc="http://creativecommons.org/ns#">
-      Ce contenu est sous licence Creative Commons
-      <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/deed.fr" target="_blank"
-        rel="license noopener noreferrer">BY-NC-SA 4.0 International
-        <img src="https://cdn.geotribu.fr/img/internal/licences/cc.svg" class=img-license-picto
-          alt="Pictogramme Creative Commons" longdesc="https://creativecommons.org/licenses/?lang=fr-FR" title="CC" />
-        <img src="https://cdn.geotribu.fr/img/internal/licences/by.svg" class=img-license-picto
-          alt="Pictogramme Creative Commons BY" longdesc="https://creativecommons.org/licenses/?lang=fr-FR"
-          title="BY" />
-        <img src="https://cdn.geotribu.fr/img/internal/licences/nc.svg" class=img-license-picto
-          alt="Pictogramme Creative Commons NC" longdesc="https://creativecommons.org/licenses/?lang=fr-FR"
-          title="NC" />
-        <img src="https://cdn.geotribu.fr/img/internal/licences/sa.svg" class=img-license-picto
-          alt="Pictogramme Creative Commons SA" longdesc="https://creativecommons.org/licenses/?lang=fr-FR"
-          title="SA" />
+    <p xmlns:cc="https://fr.wikipedia.org/wiki/Beerware">
+      Ce contenu est sous licence
+      <a href="https://fr.wikipedia.org/wiki/Beerware" target="_blank" rel="license noopener noreferrer"
+        title="Licence très permissive qui confère à l'utilisateur final le droit d'utiliser le contenu, sans conditions sauf paternité. Si l'utilisateur rencontre l'auteur, il est encouragé à lui offrir une bière ou autre en retour.">Beerware
+        <img src="https://cdn.geotribu.fr/img/internal/licences/BeerWare.svg" class=img-license-picto
+          alt="Pictogramme BeerWare" longdesc="Kita59, CC BY-SA 3.0, via Wikimedia Commons" title="Beerware" />
       </a>
     </p>
   </small>
-</div>
-<hr>
-{% elif page.meta.license == "cc4_by-sa" %}
-<div class="md-source-date">
-  <small>
-    <p xmlns:cc="http://creativecommons.org/ns#">
-      Ce contenu est sous licence Creative Commons
-      <a href="https://creativecommons.org/licenses/by-sa/4.0/deed.fr" target="_blank"
-        rel="license noopener noreferrer">BY-SA 4.0 International
-        <img src="https://cdn.geotribu.fr/img/internal/licences/cc.svg" class=img-license-picto
-          alt="Pictogramme Creative Commons" longdesc="https://creativecommons.org/licenses/?lang=fr-FR" title="CC" />
-        <img src="https://cdn.geotribu.fr/img/internal/licences/by.svg" class=img-license-picto
-          alt="Pictogramme Creative Commons BY" longdesc="https://creativecommons.org/licenses/?lang=fr-FR"
-          title="BY" />
-        <img src="https://cdn.geotribu.fr/img/internal/licences/sa.svg" class=img-license-picto
-          alt="Pictogramme Creative Commons SA" longdesc="https://creativecommons.org/licenses/?lang=fr-FR"
-          title="SA" />
-      </a>
-    </p>
-  </small>
-</div>
-{% elif page.meta.license == "beerware" %}
-<div class="md-source-date"></div>
-<small>
-  <p xmlns:cc="https://fr.wikipedia.org/wiki/Beerware">
-    Ce contenu est sous licence
-    <a href="https://fr.wikipedia.org/wiki/Beerware" target="_blank" rel="license noopener noreferrer"
-      title="Licence très permissive qui confère à l'utilisateur final le droit d'utiliser le contenu, sans conditions sauf paternité. Si l'utilisateur rencontre l'auteur, il est encouragé à lui offrir une bière ou autre en retour.">Beerware
-      <img src="https://cdn.geotribu.fr/img/internal/licences/BeerWare.svg" class=img-license-picto
-        alt="Pictogramme BeerWare" longdesc="Kita59, CC BY-SA 3.0, via Wikimedia Commons" title="Beerware" />
-    </a>
-  </p>
-</small>
-</div>
-{% endif %}
+  </div>
+  {% endif %}
 {% endif %}

--- a/content/theme/partials/license.html
+++ b/content/theme/partials/license.html
@@ -45,7 +45,7 @@
   {% elif page.meta.license == "beerware" %}
   <div class="md-source-date"></div>
   <small>
-    <p xmlns:cc="https://fr.wikipedia.org/wiki/Beerware">
+    <p xmlns:license="https://fr.wikipedia.org/wiki/Beerware">
       Ce contenu est sous licence
       <a href="https://fr.wikipedia.org/wiki/Beerware" target="_blank" rel="license noopener noreferrer"
         title="Licence très permissive qui confère à l'utilisateur final le droit d'utiliser le contenu, sans conditions sauf paternité. Si l'utilisateur rencontre l'auteur, il est encouragé à lui offrir une bière ou autre en retour.">Beerware

--- a/content/theme/partials/license.html
+++ b/content/theme/partials/license.html
@@ -8,15 +8,15 @@
       Ce contenu est sous licence Creative Commons
       <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/deed.fr" target="_blank"
         rel="license noopener noreferrer">BY-NC-SA 4.0 International
-        <img src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" class=img-license-picto
+        <img src="https://cdn.geotribu.fr/img/internal/licences/cc.svg" class=img-license-picto
           alt="Pictogramme Creative Commons" longdesc="https://creativecommons.org/licenses/?lang=fr-FR" title="CC" />
-        <img src="https://mirrors.creativecommons.org/presskit/icons/by.svg" class=img-license-picto
+        <img src="https://cdn.geotribu.fr/img/internal/licences/by.svg" class=img-license-picto
           alt="Pictogramme Creative Commons BY" longdesc="https://creativecommons.org/licenses/?lang=fr-FR"
           title="BY" />
-        <img src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" class=img-license-picto
+        <img src="https://cdn.geotribu.fr/img/internal/licences/nc.svg" class=img-license-picto
           alt="Pictogramme Creative Commons NC" longdesc="https://creativecommons.org/licenses/?lang=fr-FR"
           title="NC" />
-        <img src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" class=img-license-picto
+        <img src="https://cdn.geotribu.fr/img/internal/licences/sa.svg" class=img-license-picto
           alt="Pictogramme Creative Commons SA" longdesc="https://creativecommons.org/licenses/?lang=fr-FR"
           title="SA" />
       </a>
@@ -31,12 +31,12 @@
       Ce contenu est sous licence Creative Commons
       <a href="https://creativecommons.org/licenses/by-sa/4.0/deed.fr" target="_blank"
         rel="license noopener noreferrer">BY-SA 4.0 International
-        <img src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" class=img-license-picto
+        <img src="https://cdn.geotribu.fr/img/internal/licences/cc.svg" class=img-license-picto
           alt="Pictogramme Creative Commons" longdesc="https://creativecommons.org/licenses/?lang=fr-FR" title="CC" />
-        <img src="https://mirrors.creativecommons.org/presskit/icons/by.svg" class=img-license-picto
+        <img src="https://cdn.geotribu.fr/img/internal/licences/by.svg" class=img-license-picto
           alt="Pictogramme Creative Commons BY" longdesc="https://creativecommons.org/licenses/?lang=fr-FR"
           title="BY" />
-        <img src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" class=img-license-picto
+        <img src="https://cdn.geotribu.fr/img/internal/licences/sa.svg" class=img-license-picto
           alt="Pictogramme Creative Commons SA" longdesc="https://creativecommons.org/licenses/?lang=fr-FR"
           title="SA" />
       </a>
@@ -50,7 +50,7 @@
     Ce contenu est sous licence
     <a href="https://fr.wikipedia.org/wiki/Beerware" target="_blank" rel="license noopener noreferrer"
       title="Licence très permissive qui confère à l'utilisateur final le droit d'utiliser le contenu, sans conditions sauf paternité. Si l'utilisateur rencontre l'auteur, il est encouragé à lui offrir une bière ou autre en retour.">Beerware
-      <img src="https://upload.wikimedia.org/wikipedia/commons/d/d5/BeerWare_Logo.svg" class=img-license-picto
+      <img src="https://cdn.geotribu.fr/img/internal/licences/BeerWare.svg" class=img-license-picto
         alt="Pictogramme BeerWare" longdesc="Kita59, CC BY-SA 3.0, via Wikimedia Commons" title="Beerware" />
     </a>
   </p>


### PR DESCRIPTION
L'objectif est de faciliter la maintenance et la lecture de la partie templates du site.