### PR TITLE
Corrige les boosts par année dans la recherche

### DIFF
--- a/content/rdp/2013/.meta.yml
+++ b/content/rdp/2013/.meta.yml
@@ -1,2 +1,2 @@
 search:
-  boost: 10
+  boost: 13

--- a/content/rdp/2014/.meta.yml
+++ b/content/rdp/2014/.meta.yml
@@ -1,2 +1,2 @@
 search:
-  boost: 10
+  boost: 14

--- a/content/rdp/2015/.meta.yml
+++ b/content/rdp/2015/.meta.yml
@@ -1,2 +1,2 @@
 search:
-  boost: 10
+  boost: 15

--- a/content/rdp/2016/.meta.yml
+++ b/content/rdp/2016/.meta.yml
@@ -1,2 +1,2 @@
 search:
-  boost: 10
+  boost: 16

--- a/content/rdp/2017/.meta.yml
+++ b/content/rdp/2017/.meta.yml
@@ -1,2 +1,2 @@
 search:
-  boost: 10
+  boost: 17

--- a/content/rdp/2020/.meta.yml
+++ b/content/rdp/2020/.meta.yml
@@ -1,2 +1,2 @@
 search:
-  boost: 10
+  boost: 20

--- a/content/rdp/2021/.meta.yml
+++ b/content/rdp/2021/.meta.yml
@@ -1,2 +1,2 @@
 search:
-  boost: 10
+  boost: 21

--- a/content/rdp/2022/.meta.yml
+++ b/content/rdp/2022/.meta.yml
@@ -1,2 +1,2 @@
 search:
-  boost: 10
+  boost: 22


### PR DESCRIPTION
Les RDPs de 2013 à 2022 étaient fixées à un boost de 10.