### PR TITLE
Amélioration : insère automatiquement la date de publication à partir de l'en-tête

### DIFF
--- a/content/articles/2023/2023-09-09_tutoriel-geolocalisation-haute-precision.md
+++ b/content/articles/2023/2023-09-09_tutoriel-geolocalisation-haute-precision.md
@@ -21,7 +21,7 @@ tags:
 
 # Tutoriel : monter un kit de géolocalisation à haute précision (mobile/rover RTK)
 
-:calendar: Date de publication initiale : 9 septembre 2023
+:calendar: Date de publication initiale : {{ page.meta.date.strftime('%d %B %Y')}}
 
 ## Contexte : Le RTK quésaco ?
 

--- a/content/articles/2023/2023-09-09_tutoriel-geolocalisation-haute-precision.md
+++ b/content/articles/2023/2023-09-09_tutoriel-geolocalisation-haute-precision.md
@@ -21,7 +21,7 @@ tags:
 
 # Tutoriel : monter un kit de géolocalisation à haute précision (mobile/rover RTK)
 
-:calendar: Date de publication initiale : {{ page.meta.date.strftime('%d %B %Y')}}
+:calendar: Date de publication initiale : 9 septembre 2023
 
 ## Contexte : Le RTK quésaco ?
 

--- a/content/articles/2023/2023-12-05_prettymaps-jolies-cartes-avec-openstreetmap-python-pandas-matplotlib.md
+++ b/content/articles/2023/2023-12-05_prettymaps-jolies-cartes-avec-openstreetmap-python-pandas-matplotlib.md
@@ -7,7 +7,7 @@ categories:
     - article
     - tutoriel
 comments: true
-date: 2023-12-05 10:20
+date: 2023-12-05
 description: Prise en main du package Python 'prettymaps', un générateur de cartes artistiques et illustratives à partir d'une simple adresse, en utilisant les données OpenStreetMap et les bibliothèques osmnx, GeoPandas et matplotlib.
 icon: material/palette-outline
 image: https://cdn.geotribu.fr/img/articles-blog-rdp/articles/2023/prettymaps/prettymaps_banner.png
@@ -24,7 +24,7 @@ tags:
 
 # À la découverte de prettymaps
 
-:calendar: Date de publication initiale : 5 décembre 2023
+:calendar: Date de publication initiale : {{ page.meta.date | date_localized }}
 
 ## Introduction
 

--- a/content/articles/templates/template_article.md
+++ b/content/articles/templates/template_article.md
@@ -5,7 +5,7 @@ authors:
 categories:
     - article
 comments: true
-date: "2021-08-09 10:20"
+date: 2021-08-09
 description: "Description de 160 caractères maximum qui résume l'article qui est présente dans le flux RSS, la newsletter, les moteurs de recherche, en page d'accueil... "
 icon: "icone à choisir parmi celles disponibles dans le thème : https://squidfunk.github.io/mkdocs-material/reference/#setting-the-page-icon. Cliquer sur le + pour dérouler un mini moteur de recherche"
 image: "Image d'illustration de l'article qui sert ensuite dans la mise en avant : réseaux sociaux, flux RSS... 400x800 en PNG"
@@ -19,7 +19,7 @@ tags:
 
 # Titre principal
 
-:calendar: Date de publication initiale : 9 août 2021
+:calendar: Date de publication initiale : {{ page.meta.date | date_localized }}
 
 ## Introduction
 

--- a/content/rdp/templates/template_rdp.md
+++ b/content/rdp/templates/template_rdp.md
@@ -5,7 +5,7 @@ authors:
 categories:
     - revue de presse
 comments: true
-date: 2023-08-21 14:20
+date: 2023-08-21
 description: "Description de 160 caractères maximum qui résume la RDP. Cette description est présente dans le flux RSS, la newsletter, les moteurs de recherche, en page d'accueil... "
 image: "Image d'illustration de la RDP qui sert ensuite dans la mise en avant : réseaux sociaux, flux RSS... 400x800 en PNG"
 license: default

--- a/hooks/macros/custom_jinja.py
+++ b/hooks/macros/custom_jinja.py
@@ -1,0 +1,22 @@
+# standard
+import datetime
+
+# 3rd party
+from babel.dates import format_date
+
+
+def define_env(env):
+    """
+    This is the hook for defining variables, macros and filters
+
+    - variables: the dictionary that contains the environment variables
+    - macro: a decorator function, to declare a macro.
+    - filter: a function with one of more arguments,
+        used to perform a transformation
+    """
+
+    # create a jinja2 filter
+    @env.filter
+    def date_localized(in_date: datetime.date):
+        "Localize a date using babel."
+        return format_date(date=in_date, format="long", locale="fr_FR")

--- a/mkdocs-free.yml
+++ b/mkdocs-free.yml
@@ -43,6 +43,7 @@ plugins:
       locale: fr
   - macros:
       include_dir: content/toc_nav_ignored/snippets
+      module_name: hooks/macros/custom_jinja
   - minify:
       minify_css: true
       css_files:

--- a/mkdocs-minimal.yml
+++ b/mkdocs-minimal.yml
@@ -23,6 +23,7 @@ plugins:
         - "*.yml"
   - macros:
       include_dir: content/toc_nav_ignored/snippets
+      module_name: hooks/macros/custom_jinja
   - minify:
       minify_css: true
       css_files:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ plugins:
       lang: fr
   - macros:
       include_dir: content/toc_nav_ignored/snippets
+      module_name: hooks/macros/custom_jinja
   - tags:
       enabled: !ENV [MKDOCS_ENABLE_PLUGIN_TAGS, true]
       tags_sort_by: !!python/name:material.plugins.tags.tag_name_casefold

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ pre-commit>=3,<4
 # Project requirements
 # -----------------------
 
+babel>=2.14,<3 # pour les macros
 mkdocs-awesome-pages-plugin>=2.6,<2.10
 mkdocs-exclude>=1.0,<1.1
 mkdocs-git-authors-plugin<0.8
@@ -17,5 +18,5 @@ mkdocs-glightbox>=0.3,<0.4
 mkdocs-macros-plugin>=0.5,<1.1
 mkdocs-minify-plugin<0.9
 mkdocs-redirects<1.3
-mkdocs-rss-plugin>=1.8,<1.13
+mkdocs-rss-plugin>=1.12.1,<1.13
 termynal>=0.10,<1

--- a/scripts/new_rdp.sh
+++ b/scripts/new_rdp.sh
@@ -79,7 +79,7 @@ cp -v $RDP_TEMPLATE_PATH "$RDP_PATH"
 
 # replace default values
 sed -i "s|^title:.*|title: Revue de presse du $(date -d "${date_formatted}" '+%-d %B %Y')|" "$RDP_PATH"
-sed -i "s|^date:.*|date: $(date -d "${date_formatted}" '+%Y-%m-%d') 14:20|" "$RDP_PATH"
+sed -i "s|^date:.*|date: $(date -d "${date_formatted}" '+%Y-%m-%d')|" "$RDP_PATH"
 sed -i "s|^description:.*|description: \"\"|" "$RDP_PATH"
-sed -i "s|^# Revue de presse du.*|# Revue de presse du $(date -d "${date_formatted}" '+%-d %B %Y')|" "$RDP_PATH"
+# sed -i "s|^# Revue de presse du.*|# Revue de presse du $(date -d "${date_formatted}" '+%-d %B %Y')|" "$RDP_PATH"
 echo -e "\e[32mValeurs par défaut remplacées."


### PR DESCRIPTION
Cette PR permet de faciliter l'édition des contenus en enlevant la friction sur la date du contenu.

## Avant

Jusqu'à présent, il faut s'assurer que la date est la même dans :
 
1. le nom du fichier (format AAAA-MM-DD)
1. dans l'en-tête (format AAAA-MM-DD)
1. et dans le corps de l'article ou le titre de la RDP

```markdown
---
title: "Titre principal"
authors:
    - Prénom NOM
categories:
    - article
comments: true
date: "2021-08-09 10:20"
description: "Description de 160 caractères maximum qui résume l'article qui est présente dans le flux RSS, la newsletter, les moteurs de recherche, en page d'accueil... "
image: "Image d'illustration de l'article qui sert ensuite dans la mise en avant : réseaux sociaux, flux RSS... 400x800 en PNG"
license: default
robots: index, follow
tags:
    - tag 1
    - tag 2
    - ...
---

# Titre principal

:calendar: Date de publication initiale : 9 août 2021

## Introduction
[...]
```

## Après

- le champ `date` de l'en-tête attend le format AAAA-MM-DD
- Plus besoin du point 3. Il suffit d'insérer {{ page.meta.date | date_localized }} pour obtenir la date de l'en-tête formaté. Cela donne donc :

```markdown
---
title: "Titre principal"
authors:
    - Prénom NOM
categories:
    - article
comments: true
date: 2021-08-09
description: "Description de 160 caractères maximum qui résume l'article qui est présente dans le flux RSS, la newsletter, les moteurs de recherche, en page d'accueil... "
image: "Image d'illustration de l'article qui sert ensuite dans la mise en avant : réseaux sociaux, flux RSS... 400x800 en PNG"
license: default
robots: index, follow
tags:
    - tag 1
    - tag 2
    - ...
---

# Titre principal

:calendar: Date de publication initiale : {{ page.meta.date | date_localized }}

## Introduction
[...]
```

### Exemple

J'ai appliqué à cet article :

- syntaxe : https://github.com/geotribu/website/blob/feature/auto-date/content/articles/2023/2023-12-05_prettymaps-jolies-cartes-avec-openstreetmap-python-pandas-matplotlib.md?plain=1#L27
- rendu : https://preview-pullrequest-982--geotribu-preprod.netlify.app/articles/2023/2023-12-05_prettymaps-jolies-cartes-avec-openstreetmap-python-pandas-matplotlib/
