### PR TITLE
Refacto : utilise le plugin group du thème Material pour gérer les plugins selon le niveau d'accès

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ hooks:
 
 # Plugins
 plugins:
+  # -- COMMON --
   - awesome-pages
   - exclude:
       glob:
@@ -37,23 +38,13 @@ plugins:
       exclude:
         - index.md
       show_contribution: true
-  - git-committers:
-      enabled: !ENV [MKDOCS_ENABLE_PLUGIN_GIT_COMMITTERS, false]
-      repository: geotribu/website
-      branch: master
-      docs_path: content/
-      cache_dir:
-        !ENV [
-          MKDOCS_PLUGIN_GIT_COMMITTERS_CACHE_DIR,
-          .cache/plugins/git-committers/,
-        ]
   - git-revision-date-localized:
       enabled: !ENV [MKDOCS_ENABLE_PLUGIN_GIT_DATES, false]
       enable_creation_date: true
       fallback_to_build_date: true
       locale: fr
-  - meta:
-      meta_file: "content/**/.meta.yml"
+  - macros:
+      include_dir: content/toc_nav_ignored/snippets
   - minify:
       minify_css: true
       css_files:
@@ -64,64 +55,97 @@ plugins:
         remove_comments: true
   - search:
       lang: fr
-  - macros:
-      include_dir: content/toc_nav_ignored/snippets
-  - tags:
-      enabled: !ENV [MKDOCS_ENABLE_PLUGIN_TAGS, true]
-      tags_file: tags.md
-      tags_compare: !!python/name:material.plugins.tags.casefold
-      tags_pages_compare: !!python/name:material.plugins.tags.page_url
   - termynal
-  - privacy:
-      enabled: !ENV [MKDOCS_ENABLE_PLUGIN_PRIVACY, true]
-      cache_dir:
-        !ENV [MKDOCS_PLUGIN_PRIVACY_EXTERNAL_CACHE_DIR, .cache/plugins/privacy]
-      links_attr_map:
-        target: _blank
-      assets_exclude:
-        # mandatory - https://squidfunk.github.io/mkdocs-material/setup/ensuring-data-privacy/
-        - cdn.jsdelivr.net/npm/mathjax@3/*
-        - giscus.app/*
-        # geotribu
-        - cdn.geotribu.fr/images/*
-        - cdn.geotribu.fr/img/*
-        - geotribu.net/*
-        - www.geotribu.net/*
-        - ks356007.kimsufi.com/*
-        # external
-        - baliz-geospatial.com/images/mediatheque/2008-08/*
-        - cdn.jsdelivr.net/**/*/twemoji*
-        - cdnjs.cloudflare.com/ajax/libs/twemoji/*
-        - github.com/**/*.gif
-        - i.imgur.com/*
-        - raw.githubusercontent.com/*
-        - sondekla.com/buid/widget/*
-        - cdnjs.cloudflare.com/ajax/libs/twemoji/*
-        - twemoji.maxcdn.com/*
-        - upload.wikimedia.org/*
-        - user-images.githubusercontent.com/**/*.gif
-        # to remove later:
-        - dev.openstreetmap.org/*
-        - www.portailsig.org/assets/images/*
-        - 88.191.39.115/*
-        - cdn.theatlanticcities.com/img/*
-        - boundlessgeo.com/*
-        - i3.codeplex.com/*
-        - drfhlmcehrc34.cloudfront.net/*
-  - social:
-      enabled: !ENV [MKDOCS_ENABLE_PLUGIN_SOCIAL, true]
-      cache_dir: !ENV [MKDOCS_PLUGIN_SOCIAL_CACHE_DIR, .cache/plugins/social]
-      cards: !ENV [MKDOCS_ENABLE_PLUGIN_SOCIAL_CARDS, true]
-      cards_exclude:
-        - index.md
-        - toc_nav_ignored/*.md
-      cards_layout_options:
-        background_color: "#00000000"
-        background_image: content/theme/assets/images/geotribu/background_geotribu.png
-        color: "#3e93a7"
-        font_family: Ubuntu
 
-# Theme
+  # -- FREE --
+  - group:
+      enabled: !ENV [MKDOCS_ENABLE_THEME_INSIDERS, false]
+      plugins:
+        - social:
+            cards: !ENV [MKDOCS_ENABLE_PLUGIN_CARDS, true]
+            cards_layout_options:
+              background_color: "#56c29e"
+              font_family: Ubuntu
+        - tags:
+            enabled: !ENV [MKDOCS_ENABLE_PLUGIN_TAGS, true]
+            tags_file: tags.md
+
+  # -- INSIDERS --
+  - group:
+      enabled: !ENV [MKDOCS_ENABLE_THEME_INSIDERS, false]
+      plugins:
+        - git-committers:
+            enabled: !ENV [MKDOCS_ENABLE_PLUGIN_GIT_COMMITTERS, false]
+            repository: geotribu/website
+            branch: master
+            docs_path: content/
+            cache_dir:
+              !ENV [
+                MKDOCS_PLUGIN_GIT_COMMITTERS_CACHE_DIR,
+                .cache/plugins/git-committers/,
+              ]
+        - meta:
+            meta_file: "content/**/.meta.yml"
+        - privacy:
+            enabled: !ENV [MKDOCS_ENABLE_PLUGIN_PRIVACY, true]
+            cache_dir:
+              !ENV [
+                MKDOCS_PLUGIN_PRIVACY_EXTERNAL_CACHE_DIR,
+                .cache/plugins/privacy,
+              ]
+            links_attr_map:
+              target: _blank
+            assets_exclude:
+              # mandatory - https://squidfunk.github.io/mkdocs-material/setup/ensuring-data-privacy/
+              - cdn.jsdelivr.net/npm/mathjax@3/*
+              - giscus.app/*
+              # geotribu
+              - cdn.geotribu.fr/images/*
+              - cdn.geotribu.fr/img/*
+              - geotribu.net/*
+              - www.geotribu.net/*
+              - ks356007.kimsufi.com/*
+              # external
+              - baliz-geospatial.com/images/mediatheque/2008-08/*
+              - cdn.jsdelivr.net/**/*/twemoji*
+              - cdnjs.cloudflare.com/ajax/libs/twemoji/*
+              - github.com/**/*.gif
+              - i.imgur.com/*
+              - raw.githubusercontent.com/*
+              - sondekla.com/buid/widget/*
+              - cdnjs.cloudflare.com/ajax/libs/twemoji/*
+              - twemoji.maxcdn.com/*
+              - upload.wikimedia.org/*
+              - user-images.githubusercontent.com/**/*.gif
+              # to remove later:
+              - dev.openstreetmap.org/*
+              - www.portailsig.org/assets/images/*
+              - 88.191.39.115/*
+              - cdn.theatlanticcities.com/img/*
+              - boundlessgeo.com/*
+              - i3.codeplex.com/*
+              - drfhlmcehrc34.cloudfront.net/*
+        - social:
+            enabled: !ENV [MKDOCS_ENABLE_PLUGIN_SOCIAL, true]
+            cache_dir:
+              !ENV [MKDOCS_PLUGIN_SOCIAL_CACHE_DIR, .cache/plugins/social]
+            cards: !ENV [MKDOCS_ENABLE_PLUGIN_SOCIAL_CARDS, true]
+            cards_exclude:
+              - index.md
+              - toc_nav_ignored/*.md
+            cards_layout_options:
+              background_color: "#00000000"
+              background_image: content/theme/assets/images/geotribu/background_geotribu.png
+              color: "#3e93a7"
+              font_family: Ubuntu
+        - tags:
+            enabled: !ENV [MKDOCS_ENABLE_PLUGIN_TAGS, true]
+            tags_file: tags.md
+            tags_compare: !!python/name:material.plugins.tags.casefold
+            tags_pages_compare:
+              !!python/name:material.plugins.tags.page_url # Theme
+
+
 theme:
   name: "material"
   custom_dir: "./content/theme/"

--- a/requirements-insiders.txt
+++ b/requirements-insiders.txt
@@ -1,7 +1,7 @@
 # Insiders
 # --------
 
-git+https://${GH_TOKEN_MATERIAL_INSIDERS}@github.com/squidfunk/mkdocs-material-insiders.git@9.3.1-insiders-4.41.0#egg=mkdocs-material
+git+https://${GH_TOKEN_MATERIAL_INSIDERS}@github.com/squidfunk/mkdocs-material-insiders.git@9.4.3-insiders-4.42.0#egg=mkdocs-material
 # git+https://${GH_TOKEN_MATERIAL_INSIDERS}@github.com/squidfunk/mkdocs-material-insiders.git
 
 mkdocs-git-committers-plugin-2>=1.2,<2


### PR DESCRIPTION
Étapes :

- [ ] ventiler les plugins
- [ ] définir la variable d'environnement dans la CI/CD
- [ ] MAJ la doc sur le site de contribution


Références :

- https://squidfunk.github.io/mkdocs-material/insiders/getting-started/#built-in-plugins
- https://squidfunk.github.io/mkdocs-material/plugins/group/