### PR TITLE
Fonctionnalité : ajoute un bouton pour visualiser les sources de la page en plus de l'éditer

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -147,6 +147,9 @@ theme:
   font:
     code: Ubuntu Mono
     text: Ubuntu
+  icon:
+    edit: material/pencil
+    view: material/eye
   language: fr
   logo: theme/assets/images/geotribu/logo_geotribu.png
   palette:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -130,6 +130,7 @@ theme:
 
   features:
     - content.action.edit
+    - content.action.view
     - content.code.annotate
     - content.code.copy
     - content.code.select

--- a/requirements-insiders.txt
+++ b/requirements-insiders.txt
@@ -1,7 +1,7 @@
 # Insiders
 # --------
 
-git+https://${GH_TOKEN_MATERIAL_INSIDERS}@github.com/squidfunk/mkdocs-material-insiders.git@9.4.6-insiders-4.42.2#egg=mkdocs-material
+git+https://${GH_TOKEN_MATERIAL_INSIDERS}@github.com/squidfunk/mkdocs-material-insiders.git@9.4.8-insiders-4.43.0#egg=mkdocs-material
 # git+https://${GH_TOKEN_MATERIAL_INSIDERS}@github.com/squidfunk/mkdocs-material-insiders.git
 
 mkdocs-git-committers-plugin-2>=1.2,<2


### PR DESCRIPTION
Ajoute le bouton pour visualiser la source d'une page en plus du bouton d'édition (mais qui demande de forker pour qui n'a pas accès en écriture donc c'est assez violent) . 

Cf https://squidfunk.github.io/mkdocs-material/setup/adding-a-git-repository/#code-actions

J'en profite pour améliorer les icônes :

![image](https://github.com/geotribu/website/assets/1596222/2a871acc-95ad-44f9-901d-5b93902dc17e)  
![image](https://github.com/geotribu/website/assets/1596222/9443c4db-5eea-4168-bc52-7642f9be9b3d)
