### PR TITLE
Thème : plugin tags v2 et correction icônes de tags

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -62,6 +62,8 @@
         "tag:yaml.org,2002:python/name:material.extensions.emoji.twemoji",
         "tag:yaml.org,2002:python/name:pymdownx.superfences.fence_code_format",
         "tag:yaml.org,2002:python/name:material.plugins.tags.casefold",
-        "tag:yaml.org,2002:python/name:material.plugins.tags.page_url"
+        "tag:yaml.org,2002:python/name:material.plugins.tags.page_url",
+        "tag:yaml.org,2002:python/name:material.plugins.tags.tag_name_casefold",
+        "tag:yaml.org,2002:python/name:material.plugins.tags.item_url"
     ],
 }

--- a/content/tags.md
+++ b/content/tags.md
@@ -12,4 +12,4 @@ search:
 
 # Contenus par mots-clés
 
-[TAGS]
+<!-- material/tags -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,9 +57,8 @@ plugins:
       include_dir: content/toc_nav_ignored/snippets
   - tags:
       enabled: !ENV [MKDOCS_ENABLE_PLUGIN_TAGS, true]
-      tags_file: tags.md
-      tags_compare: !!python/name:material.plugins.tags.casefold
-      tags_pages_compare: !!python/name:material.plugins.tags.page_url
+      tags_sort_by: !!python/name:material.plugins.tags.tag_name_casefold
+      listings_sort_by: !!python/name:material.plugins.tags.item_url
   - termynal
   - privacy:
       enabled: !ENV [MKDOCS_ENABLE_PLUGIN_PRIVACY, true]

--- a/requirements-insiders.txt
+++ b/requirements-insiders.txt
@@ -1,7 +1,7 @@
 # Insiders
 # --------
 
-git+https://${GH_TOKEN_MATERIAL_INSIDERS}@github.com/squidfunk/mkdocs-material-insiders.git@9.5.1-insiders-4.47.0#egg=mkdocs-material
+git+https://${GH_TOKEN_MATERIAL_INSIDERS}@github.com/squidfunk/mkdocs-material-insiders.git@9.5.3-insiders-4.49.2#egg=mkdocs-material
 # git+https://${GH_TOKEN_MATERIAL_INSIDERS}@github.com/squidfunk/mkdocs-material-insiders.git
 
 # social plugin requirements

--- a/scripts/100_mkdocs_config_merger.py
+++ b/scripts/100_mkdocs_config_merger.py
@@ -84,7 +84,7 @@ with output_config_file.open("w", encoding="UTF-8") as out_file:
     yaml.dump(
         config_to_complete,
         out_file,
-        sort_keys=True,
+        sort_keys=False,
         default_flow_style=False,
         encoding="UTF8",
     )


### PR DESCRIPTION
Le plugin de gestion des mots-clés a subi une refonte qui implique de nombreux changements (https://github.com/squidfunk/mkdocs-material/issues/6517). Cette PR intègre les modifications nécessaires.

De plus, j'ai enfin trouvé le bug qui fait péter pas mal d'icônes de tags : https://github.com/squidfunk/mkdocs-material/issues/6635. Vu que l'ordre est significatif, j'ai désactivé le tri automatique du YAML en sortie. 