### PR TITLE
feature: désactive la numérotation systématique des lignes des bloc de code

### DIFF
--- a/mkdocs-free.yml
+++ b/mkdocs-free.yml
@@ -153,7 +153,6 @@ markdown_extensions:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.highlight:
-      linenums: true
       use_pygments: true
   - pymdownx.inlinehilite
   - pymdownx.keys

--- a/mkdocs-minimal.yml
+++ b/mkdocs-minimal.yml
@@ -91,7 +91,6 @@ markdown_extensions:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.highlight:
-      linenums: true
       use_pygments: true
   - pymdownx.inlinehilite
   - pymdownx.keys

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -209,7 +209,6 @@ markdown_extensions:
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.highlight:
       anchor_linenums: true
-      linenums: true
       line_spans: __span
       pygments_lang_class: true
       use_pygments: true


### PR DESCRIPTION
Désactive la numérotation systèématique des lignes systématique sur les blocs de code car elle est souvent inutile, pas pertinente (notamment sur les monolignes). Il faut donc l'activer par bloc de code :

````markdown 

```python title="Titre de mon bloc de code" linenums="1"
import geotribu

[...]
```

````

voir https://squidfunk.github.io/mkdocs-material/reference/code-blocks/#adding-line-numbers