### PR TITLE
mkdocs: désactive les social cards par défaut

### DIFF
--- a/.github/workflows/pr_checker_build.yml
+++ b/.github/workflows/pr_checker_build.yml
@@ -66,6 +66,8 @@ jobs:
       - name: Build in strict mode
         env:
           MKDOCS_EDIT_URI: "edit/$GITHUB_HEAD_REF/content"
+          MKDOCS_ENABLE_PLUGIN_SOCIAL: true
+          MKDOCS_ENABLE_PLUGIN_SOCIAL_CARDS: true
           MKDOCS_SITE_NAME: "Geotribu PREVIEW - PR ${{ github.event.pull_request.number }}"
           MKDOCS_SITE_COPYRIGHT: '<a href="https://www.netlify.com/"><img alt="Deploys by Netlify" src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg" style="float: right;"></a>'
         run: |

--- a/mkdocs-free.yml
+++ b/mkdocs-free.yml
@@ -52,9 +52,9 @@ plugins:
   - search:
       lang: fr
   - social:
-      enabled: !ENV [MKDOCS_ENABLE_PLUGIN_SOCIAL, true]
+      enabled: !ENV [MKDOCS_ENABLE_PLUGIN_SOCIAL, false]
       cache_dir: !ENV [MKDOCS_PLUGIN_SOCIAL_CACHE_DIR, .cache/plugins/social]
-      cards: !ENV [MKDOCS_ENABLE_PLUGIN_SOCIAL_CARDS, true]
+      cards: !ENV [MKDOCS_ENABLE_PLUGIN_SOCIAL_CARDS, false]
       cards_layout_options:
         font_family: Ubuntu
   - tags:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,7 +63,7 @@ plugins:
       listings_sort_by: !!python/name:material.plugins.tags.item_url
   - termynal
   - privacy:
-      enabled: !ENV [MKDOCS_ENABLE_PLUGIN_PRIVACY, true]
+      enabled: !ENV [MKDOCS_ENABLE_PLUGIN_PRIVACY, false]
       cache_dir:
         !ENV [MKDOCS_PLUGIN_PRIVACY_EXTERNAL_CACHE_DIR, .cache/plugins/privacy]
       links_attr_map:
@@ -99,9 +99,9 @@ plugins:
         - i3.codeplex.com/*
         - drfhlmcehrc34.cloudfront.net/*
   - social:
-      enabled: !ENV [MKDOCS_ENABLE_PLUGIN_SOCIAL, true]
+      enabled: !ENV [MKDOCS_ENABLE_PLUGIN_SOCIAL, false]
       cache_dir: !ENV [MKDOCS_PLUGIN_SOCIAL_CACHE_DIR, .cache/plugins/social]
-      cards: !ENV [MKDOCS_ENABLE_PLUGIN_SOCIAL_CARDS, true]
+      cards: !ENV [MKDOCS_ENABLE_PLUGIN_SOCIAL_CARDS, false]
       cards_exclude:
         - index.md
         - toc_nav_ignored/*.md


### PR DESCRIPTION
Étant donné les dépendances système requises, ça évite à un utilisateur "lambda" de se prendre des erreurs un peu violentes au moment du build.