### PR TITLE
Article cocarto : corrige le format de l'image d'en-tête et une typo dans le sous-titre

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -103,6 +103,9 @@ Thomas Gratier <thomas_gratier@yahoo.fr>
 
 Thomas Michel <65945567+ThomasIdgeo@users.noreply.github.com>
 
+Tristram Gräbener <tristram+git@tristramg.eu>
+Tristram Gräbener <tristram+git@tristramg.eu> <tristram+github@tristramg.eu>
+
 Utagawa VTT <16464382+utagawal@users.noreply.github.com>
 
 Valérian Lebert <vlebert@digi-stud.io>

--- a/content/articles/2024/2024-03-18_crowdscourcing_avec_cocarto.md
+++ b/content/articles/2024/2024-03-18_crowdscourcing_avec_cocarto.md
@@ -1,15 +1,15 @@
 ---
 title: "Le crowdsourcing avec cocarto"
-subtitle: "Faire participer des non-sigistes depuis sur téléphone avec un simple lien"
+subtitle: Faire participer des non-sigistes depuis leur téléphone avec un simple lien
 authors:
     - Tristram Gräbener
 categories:
     - article
 comments: true
 date: 2024-03-18
-description: "Comment utiliser cocarto pour permettre à des non-sigistes de collecter des données sur le terrain avec uniquement un smartphone"
-icon: "material/table-plus"
-image: "https://cdn.geotribu.fr/img/articles-blog-rdp/articles/2024/cocarto/banner.webp"
+description: Comment utiliser cocarto pour permettre à des non-sigistes de collecter des données sur le terrain avec uniquement un smartphone
+icon: material/table-plus
+image: https://cdn.geotribu.fr/img/articles-blog-rdp/articles/2024/cocarto/banner.png
 license: default
 robots: index, follow
 tags:


### PR DESCRIPTION
@Tristramg je fais un correctif rapide car j'avais oublié mais le format webp est trop moderne pour le flux RSS. Et une typo au passage.

J'en ai profité pour t'attribuer un commit @Michael-cd30 histoire de visibiliser ta relecture.