### PR TITLE
Fonctionnalité : ajoute un filtre Jinja pour slugify une chaîne de caractères aux templates HTML et pages Markdown

### DIFF
--- a/hooks/macros/custom_jinja.py
+++ b/hooks/macros/custom_jinja.py
@@ -3,6 +3,7 @@ import datetime
 
 # 3rd party
 from babel.dates import format_date
+from geotribu_cli.utils.slugger import sluggy
 
 
 def define_env(env):
@@ -20,3 +21,8 @@ def define_env(env):
     def date_localized(in_date: datetime.date):
         "Localize a date using babel."
         return format_date(date=in_date, format="long", locale="fr_FR")
+
+    @env.filter
+    def slugger(in_str: str, replacer: str = "-"):
+        "Text slugifier."
+        return sluggy(text_to_slugify=in_str, replacer="-")

--- a/hooks/mkdocs/G005_jinja_filters.py
+++ b/hooks/mkdocs/G005_jinja_filters.py
@@ -1,0 +1,38 @@
+# standard library
+import logging
+
+# 3rd party
+import mkdocs.plugins
+from geotribu_cli.utils.slugger import sluggy
+from jinja2 import Environment
+from mkdocs.config.defaults import MkDocsConfig
+from mkdocs.structure.files import Files
+
+# globals
+logger = logging.getLogger("mkdocs")
+
+
+@mkdocs.plugins.event_priority(-50)
+def on_env(env: Environment, config: MkDocsConfig, files: Files) -> Environment:
+    """Ajoute des fonctionnalités (filtres et tests) à l'environnement Jinja utilisé
+    par Mkdocs pour générer les pages à partir des templates.
+
+    Note importante : ces filtres ne sont pas accessibles dans les pages Markdown, mais
+    dans les templates HTML. Pour les filtres accessibles dans le Markdown, c'est via le
+    plugin mkdocs-macros et le fichier lié 'hooks/macors/custom_jinja.py'.
+
+    Args:
+        env (Environment): global Jinja Environment
+        config (MkDocsConfig): global configuration object
+        files (Files): global files collection
+
+    Returns:
+        Environment: global Jinja Environment
+    """
+    env.filters["slugger"] = sluggy
+
+    logger.info(
+        "Jinja2 filters added for templates: slugger (handy filter to slugify a string)"
+    )
+
+    return env

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ site_dir: !ENV [MKDOCS_OUTPUT_DIR, "./build/mkdocs/site"]
 hooks:
   # - hooks/mkdocs/G002_check_images_size.py
   - hooks/mkdocs/G003_social_cards_adapter.py
+  - hooks/mkdocs/G005_jinja_filters.py
 
 # Plugins
 plugins:


### PR DESCRIPTION
Voilà mon travail du we :).

Le premier objectif est d'automatiser l'intégration du bloc auteur en bas de page (sans la balise à ajouter manuellement) et la résolution des pages auteurs dans le schéma de web sémantique intégré à l'en-tête de la page (PR à suivre).

En attendant un éventuel guide dans le site de contribution, voici la syntaxe :


```jinja2
{{ author | slugger }}>
```

Si `author` a pour valeur `Tristram Gräbener`, cela donne :

```
tristram-grabener
```
