### PR TITLE
Page autrice Quy Thy Truong : complète la section `social`

### DIFF
--- a/content/team/quy-thy-truong.md
+++ b/content/team/quy-thy-truong.md
@@ -12,6 +12,7 @@ social:
         - instance:
         - username:
     - twitter:
+    - openstreetmap: https://www.openstreetmap.org/user/QualiThyAssessment
 ---
 
 # Quy Thy Truong

--- a/content/team/quy-thy-truong.md
+++ b/content/team/quy-thy-truong.md
@@ -4,10 +4,10 @@ categories:
     - contributeur
 social:
     - bluesky:
-    - github:
-    - gitlab:
-    - linkedin:
-    - mail:
+    - github: https://github.com/quythytruong
+    - gitlab: https://gitlab.com/qttruong
+    - linkedin: https://www.linkedin.com/in/quythytruong/
+    - mail: quythy.truong@oslandia.com
     - mastodon:
         - instance:
         - username:

--- a/content/team/quy-thy-truong.md
+++ b/content/team/quy-thy-truong.md
@@ -11,8 +11,9 @@ social:
     - mastodon:
         - instance:
         - username:
-    - twitter:
     - openstreetmap: https://www.openstreetmap.org/user/QualiThyAssessment
+    - osgeo:
+    - twitter:
 ---
 
 # Quy Thy Truong


### PR DESCRIPTION
A partir de la nouvelle [mise en page](https://contribuer.geotribu.fr/guides/authoring/#page-auteurice-et-bloc-signature) de la page auteur/autrice, j'ajoute mon adresse mail et mes comptes de réseaux sociaux.