### PR TITLE
Amélioration : ajoute l'étiquette sur le lien vers les commentaires

### DIFF
--- a/content/articles/2015/2015-06-04_mise_en_place_serveur_ban-bano_ubuntu.md
+++ b/content/articles/2015/2015-06-04_mise_en_place_serveur_ban-bano_ubuntu.md
@@ -37,7 +37,7 @@ Nous nous concentrons sur l'utilisation des données mais si votre rue ou votre 
 !!! note
     Ce contenu a été présenté lors du SOTM (State Of The Map) France 2015 à Brest (29) pendant la journée d'organisation libre, le Dimanche.
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ## Le géocodage, pour qui, pour quoi ?

--- a/content/articles/2020/2020-04-13_chasse_oeufs_paques_cartes_geoportail_minecraft.md
+++ b/content/articles/2020/2020-04-13_chasse_oeufs_paques_cartes_geoportail_minecraft.md
@@ -34,7 +34,7 @@ Avec le confinement, la **chasse aux œufs** est compromise pour Pâques !
 
 Alors embarquez pour une chasse aux œufs virtuelle :rabbit: :egg: :bell:, **sans sortir de chez vous** ?
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2020/2020-06-19_setup_python.md
+++ b/content/articles/2020/2020-06-19_setup_python.md
@@ -23,7 +23,7 @@ Avec le changement de braquet de la firme de Redmond par rapport à l'open sourc
 
 Ceci dit, cela fait toujours du bien de se noter quelque part les méthodes et étapes à ne pas oublier pour être rapidement confortable et efficace. Et, qui sait, en partageant, ça servira peut-être à quelqu'un et j'apprendrai des éventuels retours :slightly_smiling_face:.
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ## Installation et configuration

--- a/content/articles/2020/2020-11-21_openstreetmap_street_complete.md
+++ b/content/articles/2020/2020-11-21_openstreetmap_street_complete.md
@@ -30,7 +30,7 @@ Or, à mon sens, l'un des enjeux de la pérennité du projet réside dans sa cap
 
 Et au milieu du dernier printemps, j'ai fait la connaissance de Street Complete, une application qui facilite grandement la contribution en plus de la rendre ludique. Petite présentation en guise de coup de pub.
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ![StreetComplete](https://cdn.geotribu.fr/img/articles-blog-rdp/openstreetmap/street_complete/StreetComplete_banniere.webp "Bannière Street Complete")

--- a/content/articles/2020/2020-12-30_deployer_geotribu_a_la_maison.md
+++ b/content/articles/2020/2020-12-30_deployer_geotribu_a_la_maison.md
@@ -39,7 +39,7 @@ C'est un gage de plein de mots-clés : légèreté, réactivité, faible mainten
 
 Mais c'est surtout un bon moyen de jouer avec un site web sans se casser la tête !
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 Pour mieux se rendre compte de la légèreté et de la facilité des sites statiques, faisons un exercice simple de mise en pratique : **déployons le site actuel de Geotribu sur notre ordinateur en 2 étapes**.

--- a/content/articles/2021/2021-01-26_test_unfolded_studio.md
+++ b/content/articles/2021/2021-01-26_test_unfolded_studio.md
@@ -31,7 +31,7 @@ Après l'avoir évoqué dans [la dernière GeoRDP](../../rdp/2021/rdp_2021-01-15
 
 Si vous avez essayé Unfolded Studio, n'hésitez pas à laisser vos impressions dans les commentaires !
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2021/2021-02-02_pyqgis_previsualiser_images_integrees.md
+++ b/content/articles/2021/2021-02-02_pyqgis_previsualiser_images_integrees.md
@@ -42,7 +42,7 @@ Pour trouver les icônes, je vous renvoyais sur [le fichier de ressources de QGI
 
 Dans cet article, je vous propose de générer une page HTML dans laquelle on liste et on prévisualise les images intégrées.
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ## L'heure du script a sonné

--- a/content/articles/2021/2021-02-09_statistiques_twitter.md
+++ b/content/articles/2021/2021-02-09_statistiques_twitter.md
@@ -37,7 +37,7 @@ Et puis c'est aussi l'occasion de faire un article sur le forage de données ([u
 
 ![banner geotribu stats twitter](https://cdn.geotribu.fr/img/articles-blog-rdp/articles/stats_twitter/geotribu_stats_twitter.png "Geotribu stats Twitter"){: .img-center loading=lazy }
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ## Récupérer les données de Twitter grâce à Twint

--- a/content/articles/2021/2021-02-23_carte_ligne_libre.md
+++ b/content/articles/2021/2021-02-23_carte_ligne_libre.md
@@ -36,7 +36,7 @@ Nous proposons dans ce billet de **construire étape par étape une [carte Web 1
 
 ![carte presentation](https://cdn.geotribu.fr/img/articles-blog-rdp/articles/carte-ligne-libre/carte_presentation.JPG "Carte de presentation"){: .img-center loading=lazy }
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2021/2021-03-02_utiliser_zeal_pour_qgis_developpement.md
+++ b/content/articles/2021/2021-03-02_utiliser_zeal_pour_qgis_developpement.md
@@ -33,7 +33,7 @@ C'est un autre collègue qui m'en a reparlé récemment (coucou [Loïc](https://
 
 ![Capture d'écran de Zeal](https://cdn.geotribu.fr/img/tuto/qgis_doc_dash_zeal/zeal_search_filtered_pyqgis_qgsprovider.png "Zeal - Recherche filtrée sur PyQGIS"){: loading=lazy }
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2021/2021-04-01_qtribu_plugin_qgis_geotribu.md
+++ b/content/articles/2021/2021-04-01_qtribu_plugin_qgis_geotribu.md
@@ -39,7 +39,7 @@ Pour l'instant, le plugin permet de consulter Geotribu sans quitter QGIS. D'autr
 C'est surtout un projet "modèle" dont je me sers pour tester ou donner un exemple concret de ce que je considère comme étant de bonnes pratiques et que je présente en partie sur ce site : le [raccourci vers l'aide en ligne](2021-03-09_pyqgis_astuce_aide_plugin.md), l'utilisation des [icônes intégrées de QGIS](2021-01-19_pyqgis_utiliser_icones_integrees.md), l'intégration des options du plugin dans le menu des préférences de QGIS, la gestion centralisée des logs et messages à l'utilisateur/ice final/e, etc.
 
 [Documentation du plugin :fontawesome-solid-book:](https://geotribu.github.io/qtribu/){: .md-button }
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ## Installer le plugin

--- a/content/articles/2021/2021-04-07_carte_reseau_bus.md
+++ b/content/articles/2021/2021-04-07_carte_reseau_bus.md
@@ -30,7 +30,7 @@ Pré-requis :
 Fin 2020, une demande a émergé du service transport de ma collectivité qui souhaitait visualiser toutes les lignes de bus du territoire sur une même carte. De prime abord, cela ne me paraissait pas spécialement compliqué mais j'avais omis que plusieurs lignes pouvaient passer par des tronçons identiques et qu'il allait falloir gérer ces superpositions.  
 Après avoir parcouru internet, je suis tombé sur une solution apportée par un utilisateur sur le forum [gis.stackexchange.com](https://gis.stackexchange.com/questions/197384/how-to-split-overlapping-linestrings) et je vous propose de revenir sur la mise en oeuvre de cette solution pour nos 5 lignes de bus.
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ## Constitution du réseau de bus

--- a/content/articles/2021/2021-04-20_maplibre_site_ressource.md
+++ b/content/articles/2021/2021-04-20_maplibre_site_ressource.md
@@ -27,7 +27,7 @@ Fork open source de MapboxGL, **MapLibreGL** représente l'une des solutions act
 
 Cette bibliothèque de cartographie en ligne (côté client) repose sur la logique et la syntaxe de [MapboxGL.js](https://docs.mapbox.com/mapbox-gl-js/api/) (version 1.13). Au-delà de produire des cartes en ligne, elle offre de multiples possibilités pour la **cartographie thématique**, autement dit pour représenter sur une carte des données statistiques sous différentes formes.
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2021/2021-04-26_vectipy_postgis_mvt.md
+++ b/content/articles/2021/2021-04-26_vectipy_postgis_mvt.md
@@ -41,7 +41,7 @@ La solution que je développe ici est un projet libre de serveur permettant de p
 
 ![screenshot vectipy cadastre](https://cdn.geotribu.fr/img/articles-blog-rdp/articles/vectipy/vectipy_rendu_exemple_cadastre.png "Affichage du cadastre sur une carte web"){: loading=lazy }
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2021/2021-05-14_commentaires_migration_disqus_isso.md
+++ b/content/articles/2021/2021-05-14_commentaires_migration_disqus_isso.md
@@ -39,7 +39,7 @@ Comme évoqué dans l'introduction de [la GeoRDP du 12 mars](../../rdp/2021/rdp_
 
 Finalement, on a mis en place [Isso] et après un mois d'utilisation, il est temps de faire un retour d'expérience.
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2021/2021-05-25_biblio_powershell_si3p0.md
+++ b/content/articles/2021/2021-05-25_biblio_powershell_si3p0.md
@@ -46,7 +46,7 @@ Les géo-traitements nécessaires à cette réalisation ont été faits avec Pos
 
 Pour faire la promotion de ces travaux au sein de la collectivité, nous avons décidé de "personnifier" le SIg que nous développons. Le nom retenu est SI3P0 (pour Système d'Information 3 Point 0) pour le côté "geek" de sa consonance et en lien avec le logo 3.0 du Gard qui fait référence au code officiel géographique du département.
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2021/2021-05-28_carte_topo_qgis.md
+++ b/content/articles/2021/2021-05-28_carte_topo_qgis.md
@@ -36,7 +36,7 @@ Mais voilà, avec l'[ouverture des données de la BD TOPO®](https://geoservices
 
 A noter que ce projet vient en complément du projet [TOPen25](https://osm.cquest.org/topen25/#15/48.4018/2.7945) de [C. Quest](https://twitter.com/cq94).
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ## Le projet QGIS

--- a/content/articles/2021/2021-06-08_odk_postgis_1.md
+++ b/content/articles/2021/2021-06-08_odk_postgis_1.md
@@ -34,7 +34,7 @@ Le dernier sera consacré à la récupération des données collectées dans une
 [3 : Récupération des données dans PostGIS](2021-09-22_odk_postgis_3.md){: .md-button }
 {: align=middle }
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ## Introduction à Open Data Kit

--- a/content/articles/2021/2021-06-11_qgis_personnaliser_splash_screen.md
+++ b/content/articles/2021/2021-06-11_qgis_personnaliser_splash_screen.md
@@ -39,7 +39,7 @@ Le *splash screen* est l'image qui apparaît au lancement de QGIS. Une image que
 Le lancement de QGIS vous semble long ? Vous êtes sur la LTR et las de voir la même image pendant presque 2 ans ?  
 Depuis QGIS 3, il est possible de personnaliser cette image, alors pourquoi se priver ?
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2021/2021-06-22_odk_postgis_2.md
+++ b/content/articles/2021/2021-06-22_odk_postgis_2.md
@@ -40,7 +40,7 @@ Dans un dernier article, nous verrons comment les données collectées sur les t
 [3 : Récupération des données dans notre SI](2021-09-22_odk_postgis_3.md){: .md-button }
 {: align=middle }
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ## Introduction

--- a/content/articles/2021/2021-06-25_webmapping_avec_r.md
+++ b/content/articles/2021/2021-06-25_webmapping_avec_r.md
@@ -47,7 +47,7 @@ Vous êtes prêts ? Allez, pour bien comprendre, suivez bien les pas :trumpet:
 
 ![Carioca](https://cdn.geotribu.fr/img/articles-blog-rdp/articles/webmapping_avec_r/GrizzledCircularArmedcrab-size_restricted.gif "Carioca"){: .img-center loading=lazy }
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2021/2021-07-06_qgis_personnaliser_package_osgeo4w.md
+++ b/content/articles/2021/2021-07-06_qgis_personnaliser_package_osgeo4w.md
@@ -36,7 +36,7 @@ Vous aimez que tout soit bien paramétré pour vos utilisateurs ? Vous avez ce c
 
 Dans la lignée des articles parlant de l'installeur [OSGeo4W en ligne de commande](../2020/2020-07-03_deploy_qgis_windows.md), ou de la personnalisation du [splashscreen](2021-06-11_qgis_personnaliser_splash_screen.md), cet article vient faire un peu de publicité à une méthode pour préconfigurer tout votre environnement SIG préféré aux petits oignons.
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2021/2021-07-16_relooking_nouveautes_geotribu.md
+++ b/content/articles/2021/2021-07-16_relooking_nouveautes_geotribu.md
@@ -27,7 +27,7 @@ A noter tout de même la parution d'un article vous proposant de [préconfigurer
 
 Vous souhaitant un bel été :sun_with_face: !
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ## Une nouvelle page d'accueil

--- a/content/articles/2021/2021-08-31_pg2datagouv.md
+++ b/content/articles/2021/2021-08-31_pg2datagouv.md
@@ -44,7 +44,7 @@ Je ne vais pas vous faire un rappel sur l'ouverture des données publiques mais 
 
 En ce qui me concerne et contrairement au Parc national des Écrins, je n'ai pas de serveur à disposition pour y déposer mes données, j'ai donc développé un processus en Bash qui s'appuie sur [OGR](https://gdal.org/programs/ogr2ogr.html) pour extraire des données stockées dans une base [PostgreSQL](https://www.postgresql.org) et les publier directement sur le portail [data.gouv.fr](https://www.data.gouv.fr/fr/) à travers l'[API dédiée](https://doc.data.gouv.fr/api/intro/).
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ## pg2datagouv

--- a/content/articles/2021/2021-09-07_traiter_fichiers_adresse_gdal_csv_vrt.md
+++ b/content/articles/2021/2021-09-07_traiter_fichiers_adresse_gdal_csv_vrt.md
@@ -46,7 +46,7 @@ Pour les besoins de ce tutoriel, on va utiliser les données du plus grand dépa
 !!! tip
     Les commandes du tutoriel sont écrites en [Bash](https://en.wikipedia.org/wiki/Bash_(Unix_shell)). Elles peuvent être exécutées avec [WSL](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux) sur Windows 10+ (cf. le tuto de l'an dernier). Si vous utilisez GDAL sur Windows avec PowerShell, remplacez le caractère multi-ligne \\ (*backslash*) par ` (*backtick*).
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2021/2021-09-22_odk_postgis_3.md
+++ b/content/articles/2021/2021-09-22_odk_postgis_3.md
@@ -53,7 +53,7 @@ Une fois les données centralisés, différentes solutions d'exploitation, d'ana
 * [Google Data Studio](https://github.com/UDub-Impact/OData-Connector/issues)
 * Tableau
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 *Previously on ODK PostGIS* :

--- a/content/articles/2021/2021-10-05_lien_sig_osm.md
+++ b/content/articles/2021/2021-10-05_lien_sig_osm.md
@@ -38,7 +38,7 @@ tags:
 
 Après cette première année bien remplie à la Communauté de Communes, j'ai profité du calme estival pour travailler sur la possibilité de créer des liens entre les informations renseignées dans OpenStreetMap et les données que nous produisons en interne avec pour objectif de consolider les deux bases de données de manière réciproque. Pour l'instant, la solution proposée a été uniquement utilisée pour valider nos données ponctuelles mais n'hésitez pas à partager vos expériences avec d'autres types de données ainsi que vos adaptations éventuelles.
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2021/2021-10-15_irc_osgeo.md
+++ b/content/articles/2021/2021-10-15_irc_osgeo.md
@@ -47,7 +47,7 @@ Néanmoins, le chat est un lieu plus spontané où l'on va trouver une convivial
 
 Un lieu d'échange où vous pourrez également procrastiner sur vos tâches pros (comme les métadonnées) :wink:.
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2021/2021-10-31_retour-vers-le-futur-de-qgis-ganymede.md
+++ b/content/articles/2021/2021-10-31_retour-vers-le-futur-de-qgis-ganymede.md
@@ -29,7 +29,7 @@ Ces jours-ci je formais quelques éminents membres des [CEN](https://fr.wikipedi
 
 Alors, plus de 12 ans après [notre article "A la découverte de Quantum GIS 1.0.0"](../2009/2009-08-28_a-la-decouverte-de-qgis.md), pour fêter la Toussaint / Halloween, je vous propose d'exhumer Quantum GIS 0.x et de voir si le cadavre bouge encore :skull: :headstone:.
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2021/2021-11-09_fiche_geolecture_enfer_numerique.md
+++ b/content/articles/2021/2021-11-09_fiche_geolecture_enfer_numerique.md
@@ -39,7 +39,7 @@ Personnellement, je me considère comme étant sensible et informé des question
 L'objectif de cette fiche de géo-lecture n'est pas de résumer le livre, mais plus d'en sortir quelques idées fortes et chiffres choc.  
 J'espère sincèrement qu'il vous donnera envie de vous plonger dans ce livre, car il a changé ma manière de réfléchir sur un certain nombre de choses, et m'a donné envie d'agir différemment.
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2021/2021-11-26_traitements_data_osm_geovelo.md
+++ b/content/articles/2021/2021-11-26_traitements_data_osm_geovelo.md
@@ -34,7 +34,7 @@ Les données cyclables d’OSM sont l’un des fondements de l’activité même
 La validité, la qualité, la cohérence et la complétude de ces données sont donc des rouages essentiels de la valeur ajoutée des produits Geovelo.  
 Nous participons donc activement à la communauté OSM, notamment grâce à [l'activité de notre cartographe](https://www.openstreetmap.org/user/simon_geovelo)  !
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2021/2021-12-10_openmobilityindicators.md
+++ b/content/articles/2021/2021-12-10_openmobilityindicators.md
@@ -28,7 +28,7 @@ la nouvelle version de l'application web "Mon quartier à pied" dans le cadre du
 
 ![OpenMobilityIndicators - Clapiers](https://cdn.geotribu.fr/img/articles-blog-rdp/articles/open_mobility_indicators/OpenMobilityIndicators_clapiers.png "OpenMobilityIndicators - Clapiers"){: .img-center loading=lazy }
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2021/2021-12-31_mapscii_osm_terminal.md
+++ b/content/articles/2021/2021-12-31_mapscii_osm_terminal.md
@@ -30,7 +30,7 @@ Petit tour d'horizon.
 
 ![MapSCII 1](https://cdn.geotribu.fr/img/articles-blog-rdp/articles/mapscii/mapscii_1.png "MapSCII 1"){: .img-center loading=lazy }
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2022/2022-01-11_quantifier_inegalites_traitement_meteo.md
+++ b/content/articles/2022/2022-01-11_quantifier_inegalites_traitement_meteo.md
@@ -35,7 +35,7 @@ Ceci est mon histoire.
 
 Ce projet, complètement con sur le fond, consiste à tenter de mesurer les variations autour de zones sur une vidéo. Je m'y suis penché en me disant que ce serait une occasion de faire de me faire la main sur du machine learning, pis en fait non.
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2022/2022-01-14_etude_impacts_loi_3ds_voirie.md
+++ b/content/articles/2022/2022-01-14_etude_impacts_loi_3ds_voirie.md
@@ -37,7 +37,7 @@ Let's go !
 * Un client d'accès à la base de données type [_pgAdmin_](https://www.pgadmin.org/) ou [_DBeaver_](https://dbeaver.io/).
 * La [BD Topo® de l'IGN](https://geoservices.ign.fr/bdtopo) sur l'emprise d'étude.
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2022/2022-02-11_dashboard_qgis_adresse_CD14.md
+++ b/content/articles/2022/2022-02-11_dashboard_qgis_adresse_CD14.md
@@ -27,7 +27,7 @@ Depuis 2019, le Département accompagne les communes pour la saisie et la diffus
 
 ![QGIS label](https://cdn.geotribu.fr/img/articles-blog-rdp/articles/qgis_dashboard_calvados/intro.png  "QGIS - intro vue Dashboard"){: .img-center loading=lazy }
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2022/2022-03-08_qgis_postgis_gestion_eclairage_public.md
+++ b/content/articles/2022/2022-03-08_qgis_postgis_gestion_eclairage_public.md
@@ -41,7 +41,7 @@ Je partage ici ce travail car il pourrait, je l'espère, être utile à d'autres
 
 ![Eclairage public - Crédits : PxHere](https://cdn.geotribu.fr/img/articles-blog-rdp/articles/qgis_postgis_eclairage_public/qgis_postgis_EP.png "Éclairage public - Crédits : PxHere"){: .img-center loading=lazy }
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2022/2022-03-11_releve_terrain_qgis_input.md
+++ b/content/articles/2022/2022-03-11_releve_terrain_qgis_input.md
@@ -34,7 +34,7 @@ Input App est stable, open source et disponible pour Android et iOS. Les dévelo
 
 Dans la suite de ce tutoriel, je vais me concentrer sur cette solution, en prenant l’exemple d’un inventaire d’arbres urbains.
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2022/2022-04-18_easter_eggs_qgis_regale.md
+++ b/content/articles/2022/2022-04-18_easter_eggs_qgis_regale.md
@@ -55,7 +55,7 @@ Certaines entreprises comme Google s'en sont fait une spécialité ([carte 8 bit
 La carte est à l'évidence un media idéal pour mettre en jeu cette chasse aux oeufs qui revête d'autres aspects.  
 Revue à 4 mains des oeufs cartographiques, en particulier dans QGIS.
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2022/2022-05-24_releve_terrain_qfield.md
+++ b/content/articles/2022/2022-05-24_releve_terrain_qfield.md
@@ -26,7 +26,7 @@ tags:
 
 Pour donner suite à [l’article récent sur Input](2022-03-11_releve_terrain_qgis_input.md), et pour répondre à une perche tendue par Julien, j’ai décidé de prendre ma plume pour vous livrer un petit retour d’expérience de mon utilisation intensive de QField ces dernières années avec le cabinet Tactis.
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2022/2022-05-31_donnees_mapillary.md
+++ b/content/articles/2022/2022-05-31_donnees_mapillary.md
@@ -39,7 +39,7 @@ tags:
 
 Aujourd'hui, je vais vous présenter différentes manières d'accéder aux données identifiées à partir des prises de vue publiées sur Mapillary et qui pourront peut-être vous permettre d'enrichir votre SIG sur certaines thématiques. Pour ce faire nous allons nous appuyer sur les différents services proposés par la [4ème version de l'API](https://www.mapillary.com/developer/api-documentation/).
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 <!-- markdownlint-disable MD046 -->

--- a/content/articles/2022/2022-06-28_import-donnees-osm-postgresql-osm2pgsql-osmium.md
+++ b/content/articles/2022/2022-06-28_import-donnees-osm-postgresql-osm2pgsql-osmium.md
@@ -48,7 +48,7 @@ Compagniiiie... en mesure !
 
 ![Marche des Eléphants Postgres](https://cdn.geotribu.fr/img/articles-blog-rdp/articles/postgis_osm_setup/marche_elephants_osm_postgres.png "Marche des Eléphants Postgres"){: loading=lazy .img-center }
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2022/2022-07-11_qgis_joy_division.md
+++ b/content/articles/2022/2022-07-11_qgis_joy_division.md
@@ -32,7 +32,7 @@ La couverture de l'album 'Unknow Pleasures' du groupe Joy Division est iconique 
 
 ![Joy Division cover](https://cdn.geotribu.fr/img/articles-blog-rdp/articles/2022/2022-07-02-qgis-joy-division/joy_division_unknown_pleasures.webp "Joy Division cover"){: loading=lazy .img-center }
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2022/2022-07-22_qgis_plugin_dzetsaka.md
+++ b/content/articles/2022/2022-07-22_qgis_plugin_dzetsaka.md
@@ -28,7 +28,7 @@ Je vous propose un guide pour réaliser ce travail en prenant en main le [plugin
 
 Initialement, le plugin a été développé pour classifier différents types de végétation mais il peut être utilisé pour différencier des structures bien distinctes.
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2022/2022-08-02_API_Python_FME_travailler_avec_GDAL.md
+++ b/content/articles/2022/2022-08-02_API_Python_FME_travailler_avec_GDAL.md
@@ -37,7 +37,7 @@ Par exemple, il n'y a pas de moyen simple de générer des rasters de proximité
 
 La question est donc : comment obtenir le même résultat avec FME Workbench ?
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2022/2022-09-30_carte_facon_ed_fairburn.md
+++ b/content/articles/2022/2022-09-30_carte_facon_ed_fairburn.md
@@ -34,7 +34,7 @@ Dans ce tuto, je te propose de faire une carte inspirée de ses réalisations gr
 * Une dose de géo-données.
 * Un soupçon de créativité.
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2022/2022-11-17_zoom_circulaires_mise_en_page_qgis.md
+++ b/content/articles/2022/2022-11-17_zoom_circulaires_mise_en_page_qgis.md
@@ -34,7 +34,7 @@ Une technique qui peut améliorer considérablement l'apparence des cartes consi
 
 En 2020, nous avons eu l'occasion d'ajouter la possibilité dans les mise en page de QGIS de créer directement des zooms circulaires (grâce au parrainage de la ville de Canning, en Australie !). Bien que cette fonctionnalité facilite la création de zooms non rectangulaires, de nombreux utilisateurs de QGIS ne savent peut-être pas que c'est possible. Nous avons donc voulu mettre en avant cette fonctionnalité pour notre premier post du 30 Day Map Challenge.
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ## Zooms circulaires : exemple avec les JO de 2032

--- a/content/articles/2022/2022-12-09_mapillary_experience.md
+++ b/content/articles/2022/2022-12-09_mapillary_experience.md
@@ -44,7 +44,7 @@ tags:
 
 Cet article s'inscrit dans la continuité de l'article que j'avais intitulé [accéder aux données Mapillary et les intégrer dans son SIG](2022-05-31_donnees_mapillary.md). En effet, au moment où celui-ci avait été rédigé, je n'étais pas encore équipé pour réaliser des vues immersives. C'est maintenant chose faite et je vous propose un retour d'expérience qui je l'espère permettra d'alimenter discussions et réflexions sur le sujet.
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2023/2023-01-05_installer-qgis-sur-ubuntu.md
+++ b/content/articles/2023/2023-01-05_installer-qgis-sur-ubuntu.md
@@ -39,7 +39,7 @@ Enfin, on ne va pas râler puisque c'est gratuit, qu'on n'est pas le produit et 
 Comme je n'installe ni ne réinstalle QGIS tous les 4 matins, je me note la procédure ici histoire de pouvoir la retrouver et la partager facilement.  
 Vu que c'est un sujet vivant, je tenterai de mettre ce tutoriel à jour de temps à autre mais n'hésitez pas à signaler un souci ou à [proposer un ajustement](https://contribuer.geotribu.fr/edit/fix_content_from_website/).
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2023/2023-01-13_qgis_index_voies.md
+++ b/content/articles/2023/2023-01-13_qgis_index_voies.md
@@ -28,7 +28,7 @@ tags:
 
 Nombreuses sont les communes qui disposent d'un plan de ville, qu'elles affichent dans la rue ou qu'elles mettent à disposition sous la forme d'un dépliant, je vous partage ici la manière dont j'ai créé un listing des voies sur une expérimentation de plan de ville. Il y a sans aucun doute des choses à améliorer alors n'hésitez pas à laisser vos propositions ou vos remarques en commentaire.
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2023/2023-01-30_voeux-geotribu-2023.md
+++ b/content/articles/2023/2023-01-30_voeux-geotribu-2023.md
@@ -32,7 +32,7 @@ Malgré tout, le flux continu apporte son lot de projets excitants et pour certa
 
 Merci à toustes de nous suivre et en particulier à celles et ceux qui prennent le temps de saluer le travail bénévole qui est fait ici, à travers les commentaires ou autres moyens. Cela fait toujours plaisir aussi de voir autant de personne venir contribuer ou simplement consulter et partager nos contenus !
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2023/2023-02-21_portails-copernicus-1-donnees.md
+++ b/content/articles/2023/2023-02-21_portails-copernicus-1-donnees.md
@@ -37,7 +37,7 @@ Série **Accès aux données Copernicus/Sentinel** :
 * [Partie 2 : portails d'accès, 'the road so far'](2023-02-28_portails-copernicus-2-passe.md).
 * [Partie 3 : évolution de l'accès aux données Copernicus](2023-03-07_portails-copernicus-3-futur.md).
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2023/2023-02-28_portails-copernicus-2-passe.md
+++ b/content/articles/2023/2023-02-28_portails-copernicus-2-passe.md
@@ -41,7 +41,7 @@ Série **Accès aux données Copernicus/Sentinel** :
 * [Partie 1 : données OCS et Sentinel](2023-02-21_portails-copernicus-1-donnees.md).
 * [Partie 3 : évolution de l'accès aux données Copernicus](2023-03-07_portails-copernicus-3-futur.md).
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2023/2023-03-07_portails-copernicus-3-futur.md
+++ b/content/articles/2023/2023-03-07_portails-copernicus-3-futur.md
@@ -39,7 +39,7 @@ Série **Accès aux données Copernicus/Sentinel** :
 * [Partie 1 : données OCS et Sentinel](2023-02-21_portails-copernicus-1-donnees.md).
 * [Partie 2 : portails d'accès, 'the road so far'](2023-02-28_portails-copernicus-2-passe.md).
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2023/2023-03-12_conference-qgis-fr-2023-profil-qdt-qgis-deployment-toolbelt.md
+++ b/content/articles/2023/2023-03-12_conference-qgis-fr-2023-profil-qdt-qgis-deployment-toolbelt.md
@@ -50,7 +50,7 @@ C'est aussi l'occasion de dévoiler [QGIS Deployment Toolbelt](https://guts.gith
 - [tout au clic sur des interfaces graphiques](#jaime-le-son-du-clic)
 - [tout à la ligne de commande](#jaime-le-bruit-des-touches)
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2023/2023-03-22_images_aeriennes_historiques.md
+++ b/content/articles/2023/2023-03-22_images_aeriennes_historiques.md
@@ -36,7 +36,7 @@ tags:
 
 Il y a des projets que tu as en tête depuis des mois pour ne pas dire plus. Et puis un jour, c’est le bon moment, un créneau s’ouvre, tu t’engouffres dans la brèche happé par l’envie. Je vous propose donc de découvrir comment j’ai reconstitué des images aériennes historiques sur mon territoire à partir des imagettes disponibles sur le site : [Remonter le temps](https://remonterletemps.ign.fr) de l’IGN.
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2023/2023-04-04_journees-qgis-fr-2023-videos-geointerviews-supports.md
+++ b/content/articles/2023/2023-04-04_journees-qgis-fr-2023-videos-geointerviews-supports.md
@@ -41,7 +41,7 @@ Comment j'étais rincé à la fin de ces deux jours ! Et c'est sûrement pas à 
 
 Vivement la prochaine édition !
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2023/2023-05-24_carto-vandalisme_dans_OSM.md
+++ b/content/articles/2023/2023-05-24_carto-vandalisme_dans_OSM.md
@@ -30,7 +30,7 @@ La qualité de ces nouveaux référentiels repose sur une forte participation de
 
 C'est sur le sujet du carto-vandalisme dans OSM que j'ai axé mes recherches durant quelques années de thèse à l'IGN (coucou à mes anciens collègues du LASTIG !). Et pour éviter que mon [mémoire](https://www.researchgate.net/publication/344121146_Le_vandalisme_de_l'information_geographique_volontaire_analyse_exploratoire_et_proposition_d'une_methodologie_de_detection_automatique) ne prenne la poussière, je profite qu'on me laisse la parole au micro de GeoTribu pour partager un des fruits de mes recherches :smile:.
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2023/2023-07-25_python-obtenir-la-version-de-proj-avec-gdal-pyproj-binaire.md
+++ b/content/articles/2023/2023-07-25_python-obtenir-la-version-de-proj-avec-gdal-pyproj-binaire.md
@@ -33,7 +33,7 @@ C'est alors que mon surmoi de galérien a pris le dessus !
 
 Je me note donc ça ici, histoire de pas oublier et que ça puisse resservir.
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ## Avec pyproj

--- a/content/articles/2023/2023-08-25_geotribu-cli-en-ligne-de-commande.md
+++ b/content/articles/2023/2023-08-25_geotribu-cli-en-ligne-de-commande.md
@@ -51,7 +51,7 @@ Pour démarrer, taper : 'geotribu --help' ou 'geotribu rss'.
 
 <!-- markdownlint-enable MD040 -->
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2023/2023-09-09_tutoriel-geolocalisation-haute-precision.md
+++ b/content/articles/2023/2023-09-09_tutoriel-geolocalisation-haute-precision.md
@@ -52,7 +52,7 @@ Il s'agit d'une alternative au [projet de création de rover initié par l'INRAE
 
 :warning: Je n'ai pas de préférence pour tel ou tel produit / marque / revendeur et j'ignore la fiabilité des solutions matérielles ou logicielles choisies. Cet article a simplement pour but de partager une démarche et eventuellement d'alimenter la réflexion collective sur le sujet.
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2023/2023-10-16_panoramax-bilan-phase-construction.md
+++ b/content/articles/2023/2023-10-16_panoramax-bilan-phase-construction.md
@@ -29,7 +29,7 @@ C'était il y a un an... l'[IGN](https://www.ign.fr/) répondait à la propositi
 
 Le projet tient-il ses promesses et les contributeurs sont-ils bien au rendez-vous ?
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2023/2023-11-10_retour-conference-journees-R-2023.md
+++ b/content/articles/2023/2023-11-10_retour-conference-journees-R-2023.md
@@ -30,7 +30,7 @@ En juin dernier, Avignon a accueilli les [Rencontres R](https://rr2023.sciencesc
 
 C'est de ce point de vue que je propose ce retour sur trois jours de présentations et de discussions.
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2023/2023-12-05_prettymaps-jolies-cartes-avec-openstreetmap-python-pandas-matplotlib.md
+++ b/content/articles/2023/2023-12-05_prettymaps-jolies-cartes-avec-openstreetmap-python-pandas-matplotlib.md
@@ -41,7 +41,7 @@ Cette bibliothèque Python est un générateur de cartes statiques stylisées à
 
 Il y a déjà de nombreuses ressources et posts ([notamment sur LinkedIn](https://www.linkedin.com/search/results/content/?keywords=prettymaps&origin=FACETED_SEARCH&sid=jXj&sortBy=%22date_posted%22)) sur [prettymaps](https://github.com/marceloprates/prettymaps/) mais je n'ai rien trouvé en français ni rien qui ne détaille vraiment le fonctionnement. Alors c'est parti !
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2023/2023-12-19_duckdb-donnees-spatiales.md
+++ b/content/articles/2023/2023-12-19_duckdb-donnees-spatiales.md
@@ -30,7 +30,7 @@ tags:
 
 Si depuis quelques semaines, vous voyez passer beaucoup de choses sur des sujets comme DuckDB, les fichiers Parquet ou encore les données d’Overture Maps, mais sans trop comprendre de quoi il s’agit, vous êtes au bon endroit !
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ----

--- a/content/articles/2024/2024-02-16_de-twitter-a-mastodon-guide-geo-import-liste-comptes.md
+++ b/content/articles/2024/2024-02-16_de-twitter-a-mastodon-guide-geo-import-liste-comptes.md
@@ -49,7 +49,7 @@ Mais je suis persuadé qu'il y a un intérêt à peupler ce réseau social de ge
 Essayez. Ça n'engage à rien. Vraiment.  
 Laissez vous guider, ça va bien se passer.
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ## Choisir où créer son compte

--- a/content/articles/2024/2024-03-18_crowdscourcing_avec_cocarto.md
+++ b/content/articles/2024/2024-03-18_crowdscourcing_avec_cocarto.md
@@ -46,7 +46,7 @@ Voici le scénario proposé :
     - peuvent prendre des photos.
 - L’admin exporte ces données vers un service professionnel de cartographie
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
  {: align=middle }
 
 ## Côté adminstrateur de données

--- a/content/articles/templates/template_article.md
+++ b/content/articles/templates/template_article.md
@@ -23,7 +23,7 @@ tags:
 
 ## Introduction
 
-[Commenter cet article :fontawesome-solid-comments:](#__comments){: .md-button }
+[Commenter cet article :fontawesome-solid-comments:](#__comments "Aller aux commentaires"){: .md-button }
 {: align=middle }
 
 ## Titre 2


### PR DESCRIPTION
Ça permet d'éviter la preview automatique sur le lien du bouton de commentaires.

Avant :

![image](https://github.com/geotribu/website/assets/1596222/2f0832b6-2a63-4317-aa63-c5ab84610e5e)

Après :

![image](https://github.com/geotribu/website/assets/1596222/c4b68e5f-36b9-46ef-b2d3-5120cdf1bd98)
