### PR TITLE
ARTICLE.yml: ajout d'une limitation pour textarea

### DIFF
--- a/.github/ISSUE_TEMPLATE/ARTICLE.yml
+++ b/.github/ISSUE_TEMPLATE/ARTICLE.yml
@@ -111,7 +111,7 @@ body:
     attributes:
       label: Contenu de l'article
       description: |
-        Si vous avez déjà votre contenu, collez le ici.
+        Si vous avez déjà votre contenu, collez le ici. Longeur maximale 65536 caractères.
         La syntaxe Markdown est acceptée, mais rappelez-vous que le rendu final est celui de Material for Mkdocs et diffèrera donc de celui de GitHub. Voici [le guide de rédaction avec les principales différences de syntaxe](https://contribuer.geotribu.fr/guides/markdown_quality/#interligne-simple).
     validations:
       required: false


### PR DESCRIPTION
Ajout de la limitation github sur le nombre de caractères autorisés dans un bloc "comment" pour la taille de l'article
