### PR TITLE
Régler couleur du texte des zones de saisie des commentaires isso

### DIFF
--- a/content/theme/assets/stylesheets/extra.css
+++ b/content/theme/assets/stylesheets/extra.css
@@ -135,3 +135,13 @@ blockquote.twitter-tweet a:hover,
 blockquote.twitter-tweet a:focus {
   text-decoration: underline;
 }
+
+/* isso comments textboxes */
+
+.isso-textarea,
+.isso-post-action input,
+#isso-postbox-author,
+#isso-postbox-email,
+#isso-postbox-website {
+  color: var(--fbc-primary-text);
+}


### PR DESCRIPTION
Testé dans la console firefox, pas encore eu l'occasion de tester sur un build du site, j'arrive pas à afficher les commentaires en local

Mode sombre :
![image](https://github.com/geotribu/website/assets/40383801/b0bcce5b-ccdd-42f4-af33-2262321ae52b)

Mode clair :
![image](https://github.com/geotribu/website/assets/40383801/5458b148-eecd-4d8e-8b77-ade93a591a15)
