### PR TITLE
Fonctionnalité : ajoute le support de la syntaxe Math et LaTeX

### DIFF
--- a/content/theme/assets/javascripts/mathjax.js
+++ b/content/theme/assets/javascripts/mathjax.js
@@ -1,0 +1,19 @@
+window.MathJax = {
+    tex: {
+        inlineMath: [["\\(", "\\)"]],
+        displayMath: [["\\[", "\\]"]],
+        processEscapes: true,
+        processEnvironments: true
+    },
+    options: {
+        ignoreHtmlClass: ".*|",
+        processHtmlClass: "arithmatex"
+    }
+};
+
+document$.subscribe(() => {
+    MathJax.startup.output.clearCache()
+    MathJax.typesetClear()
+    MathJax.texReset()
+    MathJax.typesetPromise()
+})

--- a/mkdocs-free.yml
+++ b/mkdocs-free.yml
@@ -136,6 +136,12 @@ extra_javascript:
   - "theme/assets/javascripts/extra.js"
   - path: https://mastodon.social/embed.js
     defer: true
+  - path: javascripts/mathjax.js
+    async: true
+    defer: true
+  - path: https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
+    async: true
+    defer: true
   - path: https://platform.twitter.com/widgets.js
     defer: true
 
@@ -151,6 +157,8 @@ markdown_extensions:
   # Metadata - https://squidfunk.github.io/mkdocs-material/extensions/metadata
   - meta
   # PyMdown extensions - https://squidfunk.github.io/mkdocs-material/extensions/pymdown/
+  - pymdownx.arithmatex:
+      generic: true
   - pymdownx.details
   - pymdownx.emoji:
       emoji_index: !!python/name:material.extensions.emoji.twemoji

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -190,6 +190,12 @@ extra_javascript:
   - path: https://mastodon.social/embed.js
     async: true
     defer: true
+  - path: javascripts/mathjax.js
+    async: true
+    defer: true
+  - path: https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
+    async: true
+    defer: true
   - path: https://platform.twitter.com/widgets.js
     async: true
     defer: true
@@ -206,6 +212,8 @@ markdown_extensions:
   # Metadata - https://squidfunk.github.io/mkdocs-material/extensions/metadata
   - meta
   # PyMdown extensions - https://squidfunk.github.io/mkdocs-material/extensions/pymdown/
+  - pymdownx.arithmatex:
+      generic: true
   - pymdownx.details
   - pymdownx.emoji:
       emoji_index: !!python/name:material.extensions.emoji.twemoji


### PR DESCRIPTION
Voir : https://squidfunk.github.io/mkdocs-material/reference/math/

Related PR : https://github.com/geotribu/website/pull/1151#discussion_r1678305511

cc @lbartoletti 

À gauche rendu Geotribu, à droite rendu hedgedoc :

![image](https://github.com/user-attachments/assets/0342ce5a-b44e-4b6f-917d-053eb5da8bc8)


TO DO : ajouter page au guide de contribution