### PR TITLE
Modif assignees des issues de type news pour une RDP

### DIFF
--- a/.github/ISSUE_TEMPLATE/RDP_NEWS.yml
+++ b/.github/ISSUE_TEMPLATE/RDP_NEWS.yml
@@ -5,6 +5,7 @@ assignees:
   - aurelienchaumet
   - guts
   - igeofr
+  - gounux
 
 body:
   - type: markdown


### PR DESCRIPTION
PR pour revoir les personnes auxquelles sont assignées par défaut les tickets de contribution externe pour une news RDP

Pour l'instant je me suis ajouté. Vous voulez être dedans @Guts @aurelienchaumet @igeofr @Michael-cd30 ? 