### PR TITLE
Mkdocs : utilise un hook de configuration plutôt que des scripts externes (1/2)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,7 +65,6 @@ jobs:
       - name: Build static website
         run: |
           geotribu --help > content/toc_nav_ignored/snippets/code/geotribu_cli_help.txt
-          python scripts/050_mkdocs_populate_latest.py -c mkdocs.yml
           python scripts/100_mkdocs_config_merger.py -c mkdocs.yml
           mkdocs build --clean --config-file mkdocs.yml --verbose --strict
         env:

--- a/.github/workflows/links_checker.yml
+++ b/.github/workflows/links_checker.yml
@@ -35,7 +35,6 @@ jobs:
 
       - name: Build static website
         run: |
-          python scripts/050_mkdocs_populate_latest.py
           python scripts/100_mkdocs_config_merger.py -c mkdocs.yml
           mkdocs build --clean --config-file mkdocs.yml --quiet --strict
         env:

--- a/.github/workflows/pr_checker_build.yml
+++ b/.github/workflows/pr_checker_build.yml
@@ -77,7 +77,6 @@ jobs:
           export MKDOCS_SITE_URL="https://${NETLIFY_SITE_PREFIX}--${NETLIFY_SITE_NAME}.netlify.app/"
 
           # merge different configs
-          python scripts/050_mkdocs_populate_latest.py -c ${{ env.MKDOCS_CONFIG_FILENAME }}
           python scripts/100_mkdocs_config_merger.py -c ${{ env.MKDOCS_CONFIG_FILENAME }}
 
           # build

--- a/.gitignore
+++ b/.gitignore
@@ -233,3 +233,4 @@ linkchecker_report.html
 # fichiers liés aux vidéos Gource
 gource.ini
 avatars/
+mkdocs-generated-configuration.yml

--- a/config/extra_latest.yml
+++ b/config/extra_latest.yml
@@ -1,5 +1,0 @@
-# DO NOT MANUALLY EDIT THIS FILE, IT'S FILLD BY SCRIPT: scripts/mkdocs_populate_latest.py
-
-latest:
-  articles: []
-  rdp: []

--- a/hooks/mkdocs/G000_load_subconfigs.py
+++ b/hooks/mkdocs/G000_load_subconfigs.py
@@ -95,9 +95,10 @@ def on_config(config: MkDocsConfig) -> MkDocsConfig:
         MkDocsConfig: global configuration object
     """
     # determine the website flavor
-    if config.get("config_file_path") == "mkdocs.yml":
+    config_filename = Path(config.get("config_file_path")).name
+    if config_filename == "mkdocs.yml":
         config["extra"]["website_flavor"] = "insiders"
-    elif config.get("config_file_path") == "mkdocs-free.yml":
+    elif config_filename == "mkdocs-free.yml":
         config["extra"]["website_flavor"] = "community"
     else:
         config["extra"]["website_flavor"] = "minimal"

--- a/hooks/mkdocs/G000_load_subconfigs.py
+++ b/hooks/mkdocs/G000_load_subconfigs.py
@@ -22,6 +22,7 @@ from mkdocs.utils.meta import get_data
 
 
 logger = logging.getLogger("mkdocs")
+log_prefix = f"[{__name__}] "
 
 # ###########################################################################
 # ########## Functions #############
@@ -68,10 +69,10 @@ def is_mkdocs_theme_material_insiders() -> Optional[bool]:
         bool: True if the theme is Insiders edition. False if community.
     """
     if material_version is not None and "insiders" in material_version:
-        logger.debug("Material theme edition INSIDERS")
+        logger.debug(log_prefix + "Material theme edition INSIDERS")
         return True
     else:
-        logger.debug("Material theme edition COMMUNITY")
+        logger.debug(log_prefix + "Material theme edition COMMUNITY")
         return False
 
 
@@ -109,16 +110,19 @@ def on_config(config: MkDocsConfig) -> MkDocsConfig:
         and not is_mkdocs_theme_material_insiders()
     ):
         logger.warning(
-            f"Le fichier {config.get('config_file_path')} contient des paramètres ou "
+            log_prefix
+            + f"Le fichier {config.get('config_file_path')} contient des paramètres ou "
             "plugins uniquement disponibles dans la version Insiders (payante) du thème "
-            "Material. Or c'est la version community (gratuite) qui est installée : "
-            f"{material_version}. C'est donc la version communautaire (gratuite) qui "
-            "sera utilisée pour générer le site web."
+            "Material. Or c'est la version community (gratuite) qui est installée "
+            f"({material_version}). La génération va probablement échouer. Deux solutions :"
+            "A. Installer la version Insiders (requiert un jeton GitHub). "
+            "B. Utiliser la configuration basée sur la version communautaire (gratuite), "
+            "par exemple : 'mkdocs build -f mkdocs-free.yml'"
         )
         config["extra"]["website_flavor"] = "community"
 
     logger.info(
-        f"Génération du site {config.get('site_name')} "
+        log_prefix + f"Génération du site {config.get('site_name')} "
         f"en version {config.get('extra').get('website_flavor').upper()}"
     )
 

--- a/hooks/mkdocs/G000_load_subconfigs.py
+++ b/hooks/mkdocs/G000_load_subconfigs.py
@@ -135,3 +135,6 @@ def on_config(config: MkDocsConfig) -> MkDocsConfig:
         )
 
     config["extra"]["latest"] = latest_contents
+    logger.info(
+        log_prefix + "Contenus récents ajoutés à la configuration globale du site."
+    )

--- a/mkdocs-free.yml
+++ b/mkdocs-free.yml
@@ -21,6 +21,7 @@ site_dir: !ENV [MKDOCS_OUTPUT_DIR, "./build/mkdocs/site"]
 
 # Scripts pendant le build
 hooks:
+  - hooks/mkdocs/G000_load_subconfigs.py
   - hooks/mkdocs/G003_social_cards_adapter.py
   - hooks/mkdocs/G005_jinja_filters.py
   - hooks/mkdocs/G006_authors_block.py

--- a/mkdocs-minimal.yml
+++ b/mkdocs-minimal.yml
@@ -16,6 +16,7 @@ site_dir: !ENV [MKDOCS_OUTPUT_DIR, "./build/mkdocs/site"]
 
 # Scripts pendant le build
 hooks:
+  - hooks/mkdocs/G000_load_subconfigs.py
   - hooks/mkdocs/G005_jinja_filters.py
   - hooks/mkdocs/G006_authors_block.py
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ site_dir: !ENV [MKDOCS_OUTPUT_DIR, "./build/mkdocs/site"]
 
 # Scripts pendant le build
 hooks:
+  - hooks/mkdocs/G000_load_subconfigs.py
   # - hooks/mkdocs/G002_check_images_size.py
   - hooks/mkdocs/G003_social_cards_adapter.py
   - hooks/mkdocs/G005_jinja_filters.py


### PR DESCRIPTION
Première étape pour remplacer les scripts de pré-build par un hook (https://www.mkdocs.org/user-guide/configuration/#hooks).

Je découpe en 2 étapes, la deuxième nécessitant plus de travail.

Cette première PR permet de se passer du script https://github.com/geotribu/website/blob/75c03be60e36412c0329ead741bec6f7a9354e41/scripts/050_mkdocs_populate_latest.py