### PR TITLE
ci(rdp): notification matrix quand nouvelle RDP créée avec le workflow

### DIFF
--- a/.github/workflows/manual_new_rdp.yml
+++ b/.github/workflows/manual_new_rdp.yml
@@ -12,6 +12,11 @@ on:
         default: true
         description: Notifier l'équipe sur Slack
         required: false
+      notify-matrix:
+        type: boolean
+        default: true
+        description: Notifier l'équipe sur Matrix
+        required: false
 
 env:
   LANG: "fr_FR.UTF-8"
@@ -74,3 +79,17 @@ jobs:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: '{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":newspaper: La GeoRDP du ${{ env.DATE_FR_LONG }} a été créée et attend vos contributions :writing_hand: !"}},{"type":"section","fields":[{"type":"mrkdwn","text":"Créée par *${{ github.actor }}* via GitHub Action."}]},{"type":"actions","elements":[{"type":"button","text":{"type":"plain_text","emoji":true,"text":":squid: Voir la PR (GitHub)"},"url":"${{ steps.cpr.outputs.pr_url }}"},{"type":"button","text":{"type":"plain_text","emoji":true,"text":":eye: Voir la preview (Netlify)"},"style":"primary","url":"https://preview-pullrequest-${{steps.cpr.outputs.pr_number}}--geotribu-preprod.netlify.app/"}]}]}'
+
+      - name: Notification matrix
+        id: matrix-notification
+        uses: fadenb/matrix-chat-message@v0.0.6
+        if: "${{ github.event.inputs.notify-matrix == 'true' }}"
+        with:
+          homeserver: ${{ secrets.MATRIX_HOMESERVER }}
+          token: ${{ secrets.MATRIX_TOKEN }}
+          channel: ${{ secrets.MATRIX_CHANNEL }}
+          message: |
+            📰 La GeoRDP du **${{ env.DATE_FR_LONG }}** a été créée et attend vos contributions ✍️ !
+            Créée par **${{ github.actor }}** via GitHub Action.
+            [Voir la PR (GitHub)](${{ steps.cpr.outputs.pr_url }})
+            [Voir la preview (Netlify)](https://preview-pullrequest-${{steps.cpr.outputs.pr_number}}--geotribu-preprod.netlify.app/)


### PR DESCRIPTION
PR qui ajoute une notif dans matrix. À tester pour de vrai.

Pour info, le dépôt de l'action GitHub utilisée n'a pas l'air super intensément maintenu, j'ai cherché et en ai trouvé 2-3 autres qui étaient pas bien mieux..

Formatting matrix testé.