### PR TITLE
fix(build): reupload d'une image disparue (Unfolded Studio)

### DIFF
--- a/content/rdp/2020/rdp_2020-09-04.md
+++ b/content/rdp/2020/rdp_2020-09-04.md
@@ -85,11 +85,9 @@ Pour plus de détails, consulter [les notes de version](https://github.com/Leafl
 
 Suite à une collaboration avec les équipes de Google Earth, Ib Green et Ilija Puaca ont développé une version en C++ de la bibliothèque cartographique [deck.gl](https://deck.gl). Une première version ne couvrant qu'une partie limitée des fonctionnalités initiales de la bibliothèque est d'ores et déjà disponible sur le [dépôt Github du projet](https://github.com/UnfoldedInc/deck.gl-native). À noter que pour les habitués de deck.gl, les auteurs ont essayé autant que possible de rester fidèles à sa version initiale en JavaScript.
 
+![deck.gl PolygonLayer montrant les prix de l'immobilier à Vancouver, fonctionnant nativement sur un appareil iOS](https://cdn.geotribu.fr/img/articles-blog-rdp/unfolded_polygon-layer-vancouver.gif){: .img-center loading=lazy }
+
 > Source : [Unfolded](https://www.unfolded.ai/blog/2020-09-02-cross-platform-deckgl/?s=09)
-
-![DeckGL](https://www.unfolded.ai/46ae6ae487feaefc145bcccf850b17ba/polygon-layer-vancouver.gif "deck.gl PolygonLayer montrant les prix de l'immobilier à Vancouver, fonctionnant nativement sur un appareil iOS"){: loading=lazy }
-
-> deck.gl PolygonLayer montrant les prix de l'immobilier à Vancouver, fonctionnant nativement sur un appareil iOS
 
 ----
 

--- a/hooks/mkdocs/G002_check_images_size.py
+++ b/hooks/mkdocs/G002_check_images_size.py
@@ -51,7 +51,6 @@ exclude_list_url = (
     "https://cdn.geotribu.fr/img/articles-blog-rdp/capture-ecran/google_maps_pacman.gif",
     "https://cdn.geotribu.fr/img/articles-blog-rdp/capture-ecran/leaflet_compare.gif",
     "https://cdn.geotribu.fr/img/articles-blog-rdp/capture-ecran/ezgif.com-video-to-gif.gif",
-    "https://www.unfolded.ai/46ae6ae487feaefc145bcccf850b17ba/polygon-layer-vancouver.gif",
     "https://documents.buzzfeednews.com/_NewsDesign/tech/2020_08XX_Xinjiang/gm_1a_r.gif",
     "https://user-images.githubusercontent.com/6421175/107518494-5a197a00-6baf-11eb-9ab6-a054ff821cf5.gif",
     "https://github.com/giswqs/data/raw/main/timelapse/goes.gif",


### PR DESCRIPTION
Répare l'erreur de génération ici : https://github.com/geotribu/website/actions/runs/19009766756/job/54288958223#step:6:19261

Image récupérée depuis Internet Archive : https://web.archive.org/web/20200919113754/https://static.geotribu.fr/rdp/2020/rdp_2020-09-04/#une-version-c-de-deckgl

À noter que le domaine unfolded.ai semble avoir été racheté pour de la diffusion de fake news générées à partir de GenIA. @aurelienchaumet je me demande si on ne devrait pas communiquer pour prévenir vu que ton tuto est tjs très consulté.