### PR TITLE
GeoRDP 19-12-2025- Ajout news hackathon Outdoor Data Lab

### DIFF
--- a/content/rdp/2025/rdp_2025-12-19.md
+++ b/content/rdp/2025/rdp_2025-12-19.md
@@ -146,7 +146,7 @@ Découvrez les 6 projets réalisés lors du hackathon ainsi que le projet qu'il 
 
 !!! info "Contribution externe"
     Cette news est proposée par Camille Monchicourt, organisateur avec le Parc national des Écrins, via [un fork et une _Pull Request_](https://contribuer.geotribu.fr/articles/workflow/#je-nai-pas-acces-en-ecriture): [voir le ticket](https://github.com/geotribu/website/pull/1382). Merci !
-    
+
 ----
 
 ## Divers


### PR DESCRIPTION
Ajout d'une news sur le hackathon `Outdoor Data Lab`, au Parc National des Écrins en novembre dernier.