### PR TITLE
tipex(rdp): bouger news buildings + mention licence

### DIFF
--- a/content/rdp/2025/rdp_2025-12-19.md
+++ b/content/rdp/2025/rdp_2025-12-19.md
@@ -168,24 +168,6 @@ Contre-initiative engagée par la société civile, OpenStreetMap est cité comm
 
 ----
 
-## Open Data
-
-### GlobalBuildingAtlas: les pros du bâtiment
-
-![icône globe matiere](https://cdn.geotribu.fr/img/internal/icons-rdp-news/matiere.png "icône globe matiere"){: .img-thumbnail-left }
-
-Début décembre a été publié un _dataset_ de bâtiments plutôt costaud : 2.75 mi'ards de bâtiments, qui couvrent toute la surface du Globe.
-
-![_Overview_ de GlobalBuildingAtlas - récupéré depuis le GitHub](https://cdn.geotribu.fr/img/articles-blog-rdp/divers/globalbuildingatlas_overview.webp){: .img-center loading=lazy }
-
-Autre fait intéressant, 97% des bâtiments sont également fournis en [LoD1](https://www.sciencedirect.com/science/article/abs/pii/S0198971516300436), ce qui permet d'envisager des usages 3D.
-
-Si vous souhaitez en découvrir plus, vous pouvez aller zieuter [le dépôt git](https://github.com/zhu-xlab/GlobalBuildingAtlas), il y a notamment un flux WFS des familles. Le dataset pèse 36 TB, pour 1844 fichiers avec [un dépôt FTP, comme il est possible de le consulter sur la publication de l'_Université Technique de Munich_](https://mediatum.ub.tum.de/1782307).
-
-Citons également [l'article de parution du jeu de données](https://essd.copernicus.org/articles/17/6647/2025/), rédigé par l'équipe composée de Zhu, X. X., Chen, S., Zhang, F., Shi, Y. et Wang, Y.
-
-----
-
 ## Geo-event
 
 ### Le SotM Monde 2026 en France !
@@ -282,6 +264,23 @@ La montagne ça vous gagne, et la mer c'est en Bretagne ! Quelques nouvelles aus
 Un petit tour [sur flightradar24](https://www.flightradar24.com/5.79,-69.40/5) permet notamment d'examiner en temps-réel la densité d'avions au-dessus du ciel, si vous souhaitez observer en OSInt la situation dans le ciel aux environs. [Marine traffic](https://www.marinetraffic.com/en/ais/home/centerx:-54.0/centery:8.8/zoom:5) propose l'équivalent pour les bateaux et les embarcations maritimes.
 
 Les [fréquences utilisées par les constellations GNSS](https://www.taoglas.com/blogs/how-to-navigate-the-l1-l2-l5-e5a-e5b-and-g2-alphabet-soup-of-gnss-constellations-and-signals/) sont aussi affectées, altérant ainsi les possibilités de géolocalisation des usagers sur place.
+
+### GlobalBuildingAtlas: un dataset de bâtiments
+
+![icône globe matiere](https://cdn.geotribu.fr/img/internal/icons-rdp-news/matiere.png "icône globe matiere"){: .img-thumbnail-left }
+
+Début décembre a été publié un _dataset_ de bâtiments plutôt costaud : 2.75 mi'ards de bâtiments, qui couvrent toute la surface du Globe.
+
+![_Overview_ de GlobalBuildingAtlas - récupéré depuis le GitHub](https://cdn.geotribu.fr/img/articles-blog-rdp/divers/globalbuildingatlas_overview.webp){: .img-center loading=lazy }
+
+Autre fait intéressant, 97% des bâtiments sont également fournis en [LoD1](https://www.sciencedirect.com/science/article/abs/pii/S0198971516300436), ce qui permet d'envisager des usages 3D.
+
+Si vous souhaitez en découvrir plus, vous pouvez aller zieuter [le dépôt git](https://github.com/zhu-xlab/GlobalBuildingAtlas), il y a notamment un flux WFS des familles. Le dataset pèse 36 TB, pour 1844 fichiers avec [un dépôt FTP, comme il est possible de le consulter sur la publication de l'_Université Technique de Munich_](https://mediatum.ub.tum.de/1782307).
+
+Citons également [l'article de parution du jeu de données](https://essd.copernicus.org/articles/17/6647/2025/), rédigé par l'équipe composée de Zhu, X. X., Chen, S., Zhang, F., Shi, Y. et Wang, Y.
+
+!!! warning "Attention à la licence !"
+    Le _dataset_ est publié [sous licence CC-by-NC](https://creativecommons.org/licenses/by-nc/4.0/), _particulièrement déconseillée (de l'aveu même de son créateur)_. Allez [lire la partie licence de la publication](https://tubvsig-so2sat-vm1.srv.mwn.de/terms_of_use.html) avant de considérer un usage de ces données.
 
 ### La guerre russe en Ukraine, pivot d’un jeu géopolitique mondial
 


### PR DESCRIPTION
- déplacement de la news sur GlobalBuildingsAtlas hors de la rubrique `Open Data`
- ajout d'une mention sur la licence du _dataset_ et précautions d'usages

ping @vpicavet, merci pour la remontée,

CF : https://geotribu.fr/rdp/2025/rdp_2025-12-19/#isso-501