### PR TITLE
update(tooling): déplace le template de PR de RDP pour éviter qu'il ne soit utilisé le modèle par défaut

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/RDP.md
+++ b/.github/PULL_REQUEST_TEMPLATE/RDP.md
@@ -34,7 +34,7 @@ C'est par ici 👉 XXXXXXXXXX 👈
 Modèle de news ici : https://github.com/geotribu/website/blob/master/content/rdp/templates/template_rdp_news.md
 ```
 
-Exemple de [post](https://twitter.com/geotribu/status/1364625815099613185) :
+Exemple de [post](https://mapstodon.space/@geotribu/115846860375931981) sur Mastodon :
 
 ![post geordp](https://cdn.geotribu.fr/img/internal/contribution/geotribu_rdp_tweet_incitation.png)
 

--- a/.github/workflows/manual_new_rdp.yml
+++ b/.github/workflows/manual_new_rdp.yml
@@ -64,11 +64,11 @@ jobs:
         uses: repo-sync/pull-request@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          source_branch: rdp/${{ github.event.inputs.date }}
           destination_branch: "master"
           pr_allow_empty: false
+          pr_template: .github/PULL_REQUEST_TEMPLATE/RDP.md
           pr_title: "🗞 GeoRDP du ${{ env.DATE_FR_LONG }}"
-          pr_template: .github/PULL_REQUEST_TEMPLATE.md
+          source_branch: rdp/${{ github.event.inputs.date }}
 
       - name: Notification matrix
         id: matrix-notification


### PR DESCRIPTION
À suivre :

- ajouter un modèle pour soumission d'un article
- basculer de https://github.com/repo-sync/pull-request à https://github.com/peter-evans/create-pull-request