### PR TITLE
Mise à jour de l'article DuckDB

### DIFF
--- a/content/articles/2023/2023-12-19_duckdb-donnees-spatiales.md
+++ b/content/articles/2023/2023-12-19_duckdb-donnees-spatiales.md
@@ -259,7 +259,7 @@ La fonction `read_csv_auto` nous permet de pouvoir importer un CSV sans avoir à
 
 ### Traiter des données parquet d'Overture Maps avec DuckDB
 
-Les données d’Overture Maps sont fournies sous forme de fichier Parquet ([décrites ici](https://docs.overturemaps.org/overview/feature-model/)), nous allons donc importer ces données dans une base pour les consulter.
+Les données d’Overture Maps sont fournies sous forme de fichier Parquet ([décrites ici](https://docs.overturemaps.org/theme-definitions-table.html)), nous allons donc importer ces données dans une base pour les consulter.
 
 #### Importer les données dans la base
 


### PR DESCRIPTION
## Objectif 

Dans cette MR, je propose une mise à jour du tutoriel d'utilisation d'Overture Maps avec DuckDB.
Le schéma des données Parquet a été mis à jour, les requêtes n'étaient plus fonctionnelles.
Les URL S3 vers les données étaient également obsolètes.