### PR TITLE
add(tooling): ajout modèle de PR pour les articles

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/ARTICLE.md
+++ b/.github/PULL_REQUEST_TEMPLATE/ARTICLE.md
@@ -1,0 +1,71 @@
+<!-- Modèle de description pour une proposition de publication d'article. -->
+
+REMPLACER CETTE LIGNE EN DÉCRIVANT LE CONTENU DE VOTRE ARTICLE, SON OBJECTIF, LES POINTS CLÉS, ETC.
+
+----
+
+:information_source: Message automatique à lire et remplir :arrow_down:
+
+> [!IMPORTANT]
+> Rappel : votre contribution doit émaner de votre originalité et non découler d'un copier / coller issu d'un prompt.
+
+- [ ] j'ai connaissance de [la ligne et de la charte éditoriales de Geotribu](https://contribuer.geotribu.fr/requirements/#ligne-editoriale) et je garantis que ma contribution est conforme, notamment avec les lignes directrices concernant l'usage de l'IA.
+
+## Liens importants
+
+<!-- Partie réservée à l'équipe de relecture -->
+
+- pour modifier ton article via l'interface de GitHub,  tu peux le retrouver facilement via l'icône crayon en haut de la page sur le site de prévisualisation ([cf. documentation](https://contribuer.geotribu.fr/edit/fix_content_from_website/)). Sinon :
+    - [article]()
+    - [page auteur/ice]()
+- le dossier dédié pour les illustrations de l'article sur notre "[CDN](https://contribuer.geotribu.fr/guides/cdn-images-hebergement/)" : <https://cdn.geotribu.fr/tinyfilemanager.php?p=articles-blog-rdp%2Farticles>. Si besoin des accès, contacter en message privé (Mastodon, mail, Matrix,...)
+- [site temporaire de prévisualisation de l'article]() - merci de ne pas le diffuser
+
+## Ressources
+
+Pour info, voici quelques extraits de notre guide de contribution :
+
+- [comprendre et compléter l'en-tête](https://contribuer.geotribu.fr/guides/metadata_yaml_frontmatter/)
+- [**choisir une licence**](https://contribuer.geotribu.fr/guides/licensing/)
+- [**signer son article**](https://contribuer.geotribu.fr/guides/authoring/)
+- [intégrer une image](https://contribuer.geotribu.fr/guides/image/)
+- [rechercher une image déjà publiée sur Geotribu](https://contribuer.geotribu.fr/guides/cdn-images-recherche/)
+- [intégrer une vidéo](https://contribuer.geotribu.fr/guides/video/)
+- [intégrer un encart (_admonition_)](https://contribuer.geotribu.fr/guides/admonition/)
+- [utiliser des émojis](https://contribuer.geotribu.fr/guides/emoji/)
+- [intégrer des schémas / diagrammes](https://contribuer.geotribu.fr/guides/diagrams/)
+
+## 📢 Diffusion
+
+Une fois l'article publié, il sera alors temps de le diffuser. Il sera automatiquement intégré au [flux RSS](https://geotribu.fr/feed_rss_created.xml) et à [la newsletter](https://geotribu.fr/newsletter/signup/).
+
+La publication sur les réseaux sociaux est **manuelle**. Geotribu dispose de comptes officiels suivants :
+
+- [BlueSky](https://bsky.app/profile/geotribu.bsky.social)
+- ~~[Facebook](https://www.facebook.com/geotribu)~~ - inactif
+- [LinkedIn](https://www.linkedin.com/company/geotribu/)
+- [Mastodon](https://mapstodon.space/@geotribu)
+- ~~[X/Twitter](https://twitter.com/geotribu)~~ - inactif
+
+Merci d'indiquer dans ta page auteur/ice et en commentaire tes comptes à utiliser pour être cité/e dans les messages et de cocher ci-après la "stratégie" de diffusion qui te convient pour chaque réseau.
+
+### BlueSky
+
+- [ ] un/e membre de Geotribu publie, tu repartages avec ton compte
+- [ ] tu publies, on repartage
+- [ ] chacun/e publie de son côté
+- [ ] je souhaite que mon contenu ne soit pas diffusé sur ce réseau
+
+### LinkedIn
+
+- [ ] un/e membre de Geotribu publie, tu repartages avec ton compte
+- [ ] tu publies, on repartage
+- [ ] chacun/e publie de son côté
+- [ ] je souhaite que mon contenu ne soit pas diffusé sur ce réseau
+
+### Mastodon
+
+- [ ] un/e membre de Geotribu publie, tu repartages avec ton compte
+- [ ] tu publies, on repartage
+- [ ] chacun/e publie de son côté
+- [ ] je souhaite que mon contenu ne soit pas diffusé sur ce réseau


### PR DESCRIPTION
Bon pour l'instant, Github ne propose pas de choisir entre les modèles du projet au moment de créer une PR et on peut donc l['utiliser que via un paramètre d'URL](https://docs.github.com/fr/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request)... mais au moins ce sera cohérent avec https://contribuer.geotribu.fr/articles/prereview/