### PR TITLE
Ajout RDP 15-05-2025 DuckDB Quack

### DIFF
--- a/content/rdp/2026/rdp_2026-05-15.md
+++ b/content/rdp/2026/rdp_2026-05-15.md
@@ -124,7 +124,7 @@ Et oublie pas que le _Qing_ et la _Queen_ de la _grid_, c'est toi :crown: !
 
 ![logo DuckDB](https://cdn.geotribu.fr/img/logos-icones/logiciels_librairies/duckdb.png "logo DuckDB"){: .img-thumbnail-left }
 
-DuckDB, était jusqu'ici limité à un usage mono-processus, franchit un cap avec [l'annonce du protocole **Quack**](https://duckdb.org/2026/05/12/quack-remote-protocol) : il sera désormais possible de connecter plusieurs instances DuckDB entre elles en client-serveur, avec des écritures concurrentes. Le protocole repose sur HTTP, intègre une authentification par token, et affiche des performances impressionnantes (selon leurs benchmarks).
+DuckDB, jusqu'ici limité à un usage mono-processus, franchit un cap avec [l'annonce du protocole **Quack**](https://duckdb.org/2026/05/12/quack-remote-protocol) : il sera désormais possible de connecter plusieurs instances DuckDB entre elles en mode client-serveur, avec des écritures concurrentes. Le protocole repose sur HTTP, intègre une authentification par token, et affiche des performances impressionnantes (selon leurs benchmarks).
 
 Pour rappel, nous avions [déjà abordé DuckDB](https://geotribu.fr/articles/2023/2023-12-19_duckdb-donnees-spatiales/) sur Géotribu, alors limité à la lecture seule. Quack ouvre la voie à des usages multi-clients en lecture et écriture.
 

--- a/content/rdp/2026/rdp_2026-05-15.md
+++ b/content/rdp/2026/rdp_2026-05-15.md
@@ -120,6 +120,16 @@ Et oublie pas que le _Qing_ et la _Queen_ de la _grid_, c'est toi :crown: !
 
 ![Qing of the grid, Queen of the fid](https://cdn.geotribu.fr/img/articles-blog-rdp/articles/2025/retrospective_qalendrier_2025/4_qing_of_the_grid_queen_of_the_fid.webp){: .img-center loading=lazy }
 
+### DuckDB se dote d'un protocole client-serveur natif : Quack
+
+![logo DuckDB](https://cdn.geotribu.fr/img/logos-icones/logiciels_librairies/duckdb.png "logo DuckDB"){: .img-thumbnail-left }
+
+DuckDB, était jusqu'ici limité à un usage mono-processus, franchit un cap avec [l'annonce du protocole **Quack**](https://duckdb.org/2026/05/12/quack-remote-protocol) : il sera désormais possible de connecter plusieurs instances DuckDB entre elles en client-serveur, avec des écritures concurrentes. Le protocole repose sur HTTP, intègre une authentification par token, et affiche des performances impressionnantes (selon leurs benchmarks).
+
+Pour rappel, nous avions [déjà abordé DuckDB](https://geotribu.fr/articles/2023/2023-12-19_duckdb-donnees-spatiales/) sur Géotribu, alors limité à la lecture seule. Quack ouvre la voie à des usages multi-clients en lecture et écriture.
+
+Disponible dès maintenant en extension depuis `core_nightly` pour DuckDB v1.2, avec une sortie en production prévue pour la v2.0 à l'automne.
+
 ----
 
 ## Représentation Cartographique

--- a/content/rdp/2026/rdp_2026-05-15.md
+++ b/content/rdp/2026/rdp_2026-05-15.md
@@ -130,6 +130,9 @@ Pour rappel, nous avions [déjà abordé DuckDB](https://geotribu.fr/articles/20
 
 Disponible dès maintenant en extension depuis `core_nightly` pour DuckDB v1.5.2, avec une sortie stable en production prévue pour la v2.0 à l'automne.
 
+!!! info "Contribution externe"
+    Cette news est proposée par Florent Fougères via [le formulaire GitHub renouvelé](https://github.com/geotribu/website/issues/new?assignees=Guts&labels=contribution+externe%2Crdp%2Ctriage&template=RDP_NEWS.yml): [voir le ticket](https://github.com/geotribu/website/issues/1480). Merci !
+
 ----
 
 ## Représentation Cartographique

--- a/content/rdp/2026/rdp_2026-05-15.md
+++ b/content/rdp/2026/rdp_2026-05-15.md
@@ -131,7 +131,7 @@ Pour rappel, nous avions [déjà abordé DuckDB](.. /.. /articles/2023/2023-12-1
 Disponible dès maintenant en extension depuis `core_nightly` pour DuckDB v1.5.2, avec une sortie stable en production prévue pour la v2.0 à l'automne.
 
 !!! info "Contribution externe"
-    Cette news est proposée par Florent Fougères via [une Pull Request](https://github.com/geotribu/website/pull/1484]. Merci !
+    Cette news est proposée par Florent Fougères via [une Pull Request](<https://github.com/geotribu/website/pull/1484>]. Merci !
 
 ----
 

--- a/content/rdp/2026/rdp_2026-05-15.md
+++ b/content/rdp/2026/rdp_2026-05-15.md
@@ -126,7 +126,7 @@ Et oublie pas que le _Qing_ et la _Queen_ de la _grid_, c'est toi :crown: !
 
 DuckDB, jusqu'ici limité à un usage mono-processus, franchit un cap avec [l'annonce du protocole **Quack**](https://duckdb.org/2026/05/12/quack-remote-protocol) : il sera désormais possible de connecter plusieurs instances DuckDB entre elles en mode client-serveur, avec des écritures concurrentes. Le protocole repose sur HTTP, intègre une authentification par token, et affiche des performances impressionnantes (selon leurs benchmarks).
 
-Pour rappel, nous avions [déjà abordé DuckDB](https://geotribu.fr/articles/2023/2023-12-19_duckdb-donnees-spatiales/) sur Géotribu, alors limité à la lecture seule. Quack ouvre la voie à des usages multi-clients en lecture et écriture.
+Pour rappel, nous avions [déjà abordé DuckDB](.. /.. /articles/2023/2023-12-19_duckdb-donnees-spatiales/) sur Géotribu, alors limité à la lecture seule. Quack ouvre la voie à des usages multi-clients en lecture et écriture.
 
 Disponible dès maintenant en extension depuis `core_nightly` pour DuckDB v1.5.2, avec une sortie stable en production prévue pour la v2.0 à l'automne.
 

--- a/content/rdp/2026/rdp_2026-05-15.md
+++ b/content/rdp/2026/rdp_2026-05-15.md
@@ -131,7 +131,7 @@ Pour rappel, nous avions [déjà abordé DuckDB](.. /.. /articles/2023/2023-12-1
 Disponible dès maintenant en extension depuis `core_nightly` pour DuckDB v1.5.2, avec une sortie stable en production prévue pour la v2.0 à l'automne.
 
 !!! info "Contribution externe"
-    Cette news est proposée par Florent Fougères via [le formulaire GitHub renouvelé](https://github.com/geotribu/website/issues/new?assignees=Guts&labels=contribution+externe%2Crdp%2Ctriage&template=RDP_NEWS.yml): [voir le ticket](https://github.com/geotribu/website/issues/1480). Merci !
+    Cette news est proposée par Florent Fougères via [une Pull Request](https://github.com/geotribu/website/pull/1484]. Merci !
 
 ----
 

--- a/content/rdp/2026/rdp_2026-05-15.md
+++ b/content/rdp/2026/rdp_2026-05-15.md
@@ -128,7 +128,7 @@ DuckDB, était jusqu'ici limité à un usage mono-processus, franchit un cap ave
 
 Pour rappel, nous avions [déjà abordé DuckDB](https://geotribu.fr/articles/2023/2023-12-19_duckdb-donnees-spatiales/) sur Géotribu, alors limité à la lecture seule. Quack ouvre la voie à des usages multi-clients en lecture et écriture.
 
-Disponible dès maintenant en extension depuis `core_nightly` pour DuckDB v1.2, avec une sortie en production prévue pour la v2.0 à l'automne.
+Disponible dès maintenant en extension depuis `core_nightly` pour DuckDB v1.5.2, avec une sortie stable en production prévue pour la v2.0 à l'automne.
 
 ----
 


### PR DESCRIPTION
Ajout d'une brève dans la prochaine RDP sur l'annonce du protocole DuckDB Quack : https://duckdb.org/2026/05/12/quack-remote-protocol