### PR TITLE
update(thème): adapter le background de la page d'accueil au mode clair/sombre

### DIFF
--- a/content/theme/assets/stylesheets/homepage.css
+++ b/content/theme/assets/stylesheets/homepage.css
@@ -29,12 +29,7 @@
 /* Hero */
 .tx-container {
   padding-top: 0rem;
-  background: linear-gradient(
-    to bottom,
-    var(--md-primary-fg-color),
-    #56c29e 99%,
-    #fff 99%
-  );
+  background: var(--md-default-bg-color);
 }
 
 .tx-hero {
@@ -56,7 +51,7 @@
 }
 
 .tx-hero p {
-  color: currentColor;
+  color: var(--md-default-fg-color);
   font-weight: 400;
   font-size: 20px;
   line-height: 32px;


### PR DESCRIPTION
Proposition de background pour le "bandeau vert Geotribu" de la page d'accueil qui suit celui du site :

- Blanc en mode clair
- Noir (bleuté, s'il vous plait!) en mode sombre

J'ai modifié deux trucs:
- background du `tx-container`
- color du `.tx-hero p`

Par contre, je ne sais pourquoi, d'autres modifs sont détectées sans y avoir touché (formatage du css à priori sans conséquence).

ps : Premier PR, je sais pas si je fais tout bien, merci de votre vigilance et de votre indulgence ;)

Antoine