### PR TITLE
Changement de la couleur du texte des commentaires

### DIFF
--- a/content/theme/assets/stylesheets/extra.css
+++ b/content/theme/assets/stylesheets/extra.css
@@ -151,5 +151,5 @@ blockquote.twitter-tweet a:focus {
 #isso-postbox-author,
 #isso-postbox-email,
 #isso-postbox-website {
-  color: var(--fbc-primary-text);
+  color: var(--isso-primary-text-color);
 }


### PR DESCRIPTION
Changement de la couleur du texte pour la rédaction des commentaires. C’était presque invisible en mode sombre (voir [issue](https://github.com/geotribu/website/issues/1487))

Test fait à partir d'une nouvelle installation en local d'isso (je n'ai pas réussi avec la conf geotribu).

Test ok sur Firefox et Chromium. 