### PR TITLE
Thème : petites amélioriations

### DIFF
--- a/content/theme/assets/stylesheets/extra.css
+++ b/content/theme/assets/stylesheets/extra.css
@@ -156,10 +156,7 @@ blockquote.twitter-tweet a:focus {
 
 /*Couleur plus accentuée des textes dans les nav de droite et gauche*/
 
-.md-nav--primary .md-nav__item .md-nav__link--active {
-	color: var(--md-typeset-a-color);
-}
-
+.md-nav--primary .md-nav__item .md-nav__link--active,
 .md-nav--secondary .md-nav__link--active {
 	color: var(--md-typeset-a-color);
 }

--- a/content/theme/assets/stylesheets/extra.css
+++ b/content/theme/assets/stylesheets/extra.css
@@ -153,3 +153,13 @@ blockquote.twitter-tweet a:focus {
 #isso-postbox-website {
   color: var(--fbc-primary-text);
 }
+
+/*Couleur plus accentuée des textes dans les nav de droite et gauche*/
+
+.md-nav--primary .md-nav__item .md-nav__link--active {
+	color: var(--md-typeset-a-color);
+}
+
+.md-nav--secondary .md-nav__link--active {
+	color: var(--md-typeset-a-color);
+}

--- a/content/theme/assets/stylesheets/homepage.css
+++ b/content/theme/assets/stylesheets/homepage.css
@@ -286,6 +286,7 @@
 .secondary-section .g .section .component-wrapper .responsive-grid .card:hover {
   box-shadow: var(--md-accent-fg-color--transparent) 0.3125rem 0.3125rem 0px -0.0625rem,
     var(--md-accent-bg-color--light) 0px 0.25rem 0.5rem 0px;
+  background-color: var(--md-primary-fg-color--transparent);
 }
 
 @media screen and (min-width: 75rem) {

--- a/content/theme/assets/stylesheets/homepage.css
+++ b/content/theme/assets/stylesheets/homepage.css
@@ -395,7 +395,13 @@
   font-weight: 600;
 }
 
-.component-wrapper .responsive-grid a:hover {
+/*Style des grid au survol pour plus d'accentuation*/
+
+.component-wrapper .responsive-grid a:hover{
   color: var(--md-typeset-a-color);
   background: var(--md-accent-fg-color--transparent);
+}
+
+.component-wrapper .responsive-grid a:hover h5 {
+  color: var(--md-typeset-a-color) !important;
 }


### PR DESCRIPTION
Bien le bonsoir ! 

La PR associée à l'issue  [#1493](https://github.com/geotribu/website/issues/1493#issue-4634965044)

__1. Accentuation du survol des grid de la page d'accueil__

- Mode clair actuel : 

<img width="807" height="289" alt="Image" src="https://github.com/user-attachments/assets/461feac1-dd46-463e-ba32-cbdd1fe9c33f" />

- Mode clair après (un petit vert tout en douceur) :

<img width="807" height="289" alt="Image" src="https://github.com/user-attachments/assets/180fa213-1122-4d1f-926e-0df942004083" />

- Mode sombre actuel : 

<img width="807" height="289" alt="Image" src="https://github.com/user-attachments/assets/8c17ca53-a99f-4645-8137-1d5082fc75af" />

- Mode sombre après (le background est un poil plus lumineux et le titre prend le bleu des liens): 

<img width="807" height="289" alt="Image" src="https://github.com/user-attachments/assets/fcdb5047-728c-44de-bb80-f323fd960186" />

__2. Accentuation des titres des sections de navigation en mode sombre__

Le contraste entre le fond et la couleur du texte est peut-être limite. J'ai repris la couleur des liens (comme le mode clair qui utilise le "vert Géotribu"). Je me suis retenu pour mettre du "vert Géotribu" à la place du bleu...

- Avant (contraste moyen pour l'article en cours):

<img width="515" height="326" alt="Image" src="https://github.com/user-attachments/assets/0a8589d4-8584-4e25-8aa3-f148091900a7" />

- Après (c'est plus clair en bleu non?) :

<img width="515" height="326" alt="Image" src="https://github.com/user-attachments/assets/10de7044-71e5-45df-82a2-317863fc3792" />

Dispo pour vos retours !