### PR TITLE
Fix/bluesky redirect 1520

### DIFF
--- a/content/theme/partials/contributors_social.html.jinja
+++ b/content/theme/partials/contributors_social.html.jinja
@@ -40,6 +40,13 @@
             {% include ".icons/fontawesome/brands/mastodon.svg" %}
         </span>
     </a>
+    {% elif network == "bluesky" %}
+    <a href="https://bsky.app/profile/{{ value }}" target="_blank" rel="noopener"
+        aria-label="Profil Bluesky de {{ page.meta.title }}">
+        <span class="twemoji">
+            {% include ".icons/fontawesome/brands/bluesky.svg" %}
+        </span>
+    </a>
     {% elif network == "openstreetmap" %}
     <a href="https://www.openstreetmap.org/user/{{ value }}" target="_blank" rel="noopener"
         aria-label="Profil OpenStreetMap de {{ page.meta.title }}">

--- a/content/theme/partials/contributors_social.html.jinja
+++ b/content/theme/partials/contributors_social.html.jinja
@@ -41,22 +41,9 @@
         </span>
     </a>
     {% elif network == "bluesky" %}
+    {# Simplified handling per review: prefer mapping {username, instance}; fallback to bsky.app/profile/{value} #}
     {% if value and value.username and value.instance %}
     <a href="https://{{ value.instance }}/profile/{{ value.username }}" target="_blank" rel="noopener"
-        aria-label="Profil Bluesky de {{ page.meta.title }}">
-        <span class="twemoji">
-            {% include ".icons/fontawesome/brands/bluesky.svg" %}
-        </span>
-    </a>
-    {% elif value and value.startswith('http') %}
-    <a href="{{ value }}" target="_blank" rel="noopener"
-        aria-label="Profil Bluesky de {{ page.meta.title }}">
-        <span class="twemoji">
-            {% include ".icons/fontawesome/brands/bluesky.svg" %}
-        </span>
-    </a>
-    {% elif value and '.' in value %}
-    <a href="https://bsky.app/profile/{{ value }}" target="_blank" rel="noopener"
         aria-label="Profil Bluesky de {{ page.meta.title }}">
         <span class="twemoji">
             {% include ".icons/fontawesome/brands/bluesky.svg" %}

--- a/content/theme/partials/contributors_social.html.jinja
+++ b/content/theme/partials/contributors_social.html.jinja
@@ -41,12 +41,35 @@
         </span>
     </a>
     {% elif network == "bluesky" %}
+    {% if value and value.username and value.instance %}
+    <a href="https://{{ value.instance }}/profile/{{ value.username }}" target="_blank" rel="noopener"
+        aria-label="Profil Bluesky de {{ page.meta.title }}">
+        <span class="twemoji">
+            {% include ".icons/fontawesome/brands/bluesky.svg" %}
+        </span>
+    </a>
+    {% elif value and value.startswith('http') %}
+    <a href="{{ value }}" target="_blank" rel="noopener"
+        aria-label="Profil Bluesky de {{ page.meta.title }}">
+        <span class="twemoji">
+            {% include ".icons/fontawesome/brands/bluesky.svg" %}
+        </span>
+    </a>
+    {% elif value and '.' in value %}
     <a href="https://bsky.app/profile/{{ value }}" target="_blank" rel="noopener"
         aria-label="Profil Bluesky de {{ page.meta.title }}">
         <span class="twemoji">
             {% include ".icons/fontawesome/brands/bluesky.svg" %}
         </span>
     </a>
+    {% elif value %}
+    <a href="https://bsky.app/profile/{{ value }}" target="_blank" rel="noopener"
+        aria-label="Profil Bluesky de {{ page.meta.title }}">
+        <span class="twemoji">
+            {% include ".icons/fontawesome/brands/bluesky.svg" %}
+        </span>
+    </a>
+    {% endif %}
     {% elif network == "openstreetmap" %}
     <a href="https://www.openstreetmap.org/user/{{ value }}" target="_blank" rel="noopener"
         aria-label="Profil OpenStreetMap de {{ page.meta.title }}">


### PR DESCRIPTION
Closes #1520
Permet la redirection vers bsky.app au lieu de bluesky.com pour les liens de réseaux sociaux des auteurs