### PR TITLE
RDP 2026 09 04 : news rachat DuckDB par AWS

### DIFF
--- a/content/rdp/2026/rdp_2026-09-04.md
+++ b/content/rdp/2026/rdp_2026-09-04.md
@@ -139,6 +139,12 @@ Venez lire [le _Visual Changelog_ de cette version de référence](https://www.q
 
 Vous pouvez également vous replonger dans [l'article de 2025](../../articles/2025/2025-01-28_tester-qgis-4-futur-sig-open-source.md) rédigé par [Julien](../../team/julien-moura.md), qui donne à voir ce qu'implique une telle montée de version pour le projet. Ainsi que dans [notre Qalendrier QGIS4 de Décembre dernier](../../articles/2025/2025-12-25_qalendrier_decembre_2025.md) par [Guilhem](../../team/guilhem-allaman.md), disponible également [via un format diapositives en anglais](https://slides.geotribu.net/2025-12-25_geotribu_2025_qalendar_en.html#/).
 
+### DuckDB
+
+![logo Duckdb](https://cdn.geotribu.fr/img/logos-icones/logiciels_librairies//duckdb.png "logo DuckDB"{: .img-thumbnail-left }
+
+De manière peut-être un peu moins réjouissante, DuckLabs, l'entité derrière DuckDB, vient de se faire acquérir par Amazon. On nous garantie que le projet va rester open source, mais des doutes peuvent êtres soulevés sur les possibles reversement au projet communautaire des développements faits en interne pour AWS. Un peu à la manière de se que font déjà les géants du web avec leurs forks de PostgreSQL (pensez AlloyDB, AuroraDB, les forks de Google et d'Amazon du dit PostgreSQL). Au delà des paroles rassurantes et du damage control des différents communicants, ce que cela veut dire exactement pour le projet reste à découvrir...
+
 ----
 
 ## Représentation Cartographique

--- a/content/rdp/2026/rdp_2026-09-04.md
+++ b/content/rdp/2026/rdp_2026-09-04.md
@@ -139,7 +139,7 @@ Venez lire [le _Visual Changelog_ de cette version de référence](https://www.q
 
 Vous pouvez également vous replonger dans [l'article de 2025](../../articles/2025/2025-01-28_tester-qgis-4-futur-sig-open-source.md) rédigé par [Julien](../../team/julien-moura.md), qui donne à voir ce qu'implique une telle montée de version pour le projet. Ainsi que dans [notre Qalendrier QGIS4 de Décembre dernier](../../articles/2025/2025-12-25_qalendrier_decembre_2025.md) par [Guilhem](../../team/guilhem-allaman.md), disponible également [via un format diapositives en anglais](https://slides.geotribu.net/2025-12-25_geotribu_2025_qalendar_en.html#/).
 
-### DuckDB
+### DuckDB rejoint Amazon dans les nuages
 
 ![logo Duckdb](https://cdn.geotribu.fr/img/logos-icones/logiciels_librairies/duckdb.png "logo QGIS"){: .img-thumbnail-left }
 

--- a/content/rdp/2026/rdp_2026-09-04.md
+++ b/content/rdp/2026/rdp_2026-09-04.md
@@ -141,7 +141,7 @@ Vous pouvez également vous replonger dans [l'article de 2025](../../articles/20
 
 ### DuckDB
 
-![logo Duckdb](https://cdn.geotribu.fr/img/logos-icones/logiciels_librairies/duckdb.png "logo DuckDB"{: .img-thumbnail-left }
+![logo Duckdb](https://cdn.geotribu.fr/img/logos-icones/logiciels_librairies/duckdb.png "logo QGIS"){: .img-thumbnail-left }
 
 De manière peut-être un peu moins réjouissante, DuckLabs, l'entité derrière DuckDB, vient de se faire acquérir par Amazon. On nous garantie que le projet va rester open source, mais des doutes peuvent êtres soulevés sur les possibles reversement au projet communautaire des développements faits en interne pour AWS. Un peu à la manière de se que font déjà les géants du web avec leurs forks de PostgreSQL (pensez AlloyDB, AuroraDB, les forks de Google et d'Amazon du dit PostgreSQL). Au delà des paroles rassurantes et du damage control des différents communicants, ce que cela veut dire exactement pour le projet reste à découvrir...
 

--- a/content/rdp/2026/rdp_2026-09-04.md
+++ b/content/rdp/2026/rdp_2026-09-04.md
@@ -145,6 +145,9 @@ Vous pouvez également vous replonger dans [l'article de 2025](../../articles/20
 
 De manière peut-être un peu moins réjouissante, [DuckLabs](https://ducklabs.com/), l'entité derrière DuckDB, [vient de se faire acquérir par Amazon](https://motherduck.com/blog/duckdb-amazon/). On nous garantie que le projet va rester open source, mais des doutes peuvent être soulevés sur les possibles reversement au projet communautaire des développements faits en interne pour AWS. Un peu à la manière de ce que font déjà les géants du web avec leurs forks de PostgreSQL (pensez AlloyDB, AuroraDB, les forks de Google et d'Amazon du dit PostgreSQL). Au delà des paroles rassurantes et du _damage control_ des différents communicants, ce que cela veut dire exactement pour le projet reste à découvrir...
 
+!!! info "Contribution externe"
+    Cette news est proposée par Thomas Szczurek-Gayant via [une _Pull Request_ GitHub](https://github.com/geotribu/website/pull/1524). Merci !
+
 ----
 
 ## Représentation Cartographique

--- a/content/rdp/2026/rdp_2026-09-04.md
+++ b/content/rdp/2026/rdp_2026-09-04.md
@@ -143,7 +143,7 @@ Vous pouvez également vous replonger dans [l'article de 2025](../../articles/20
 
 ![logo Duckdb](https://cdn.geotribu.fr/img/logos-icones/logiciels_librairies/duckdb.png "logo QGIS"){: .img-thumbnail-left }
 
-De manière peut-être un peu moins réjouissante, DuckLabs, l'entité derrière DuckDB, vient de se faire acquérir par Amazon. On nous garantie que le projet va rester open source, mais des doutes peuvent êtres soulevés sur les possibles reversement au projet communautaire des développements faits en interne pour AWS. Un peu à la manière de se que font déjà les géants du web avec leurs forks de PostgreSQL (pensez AlloyDB, AuroraDB, les forks de Google et d'Amazon du dit PostgreSQL). Au delà des paroles rassurantes et du damage control des différents communicants, ce que cela veut dire exactement pour le projet reste à découvrir...
+De manière peut-être un peu moins réjouissante, [DuckLabs](https://ducklabs.com/), l'entité derrière DuckDB, [vient de se faire acquérir par Amazon](https://motherduck.com/blog/duckdb-amazon/). On nous garantie que le projet va rester open source, mais des doutes peuvent être soulevés sur les possibles reversement au projet communautaire des développements faits en interne pour AWS. Un peu à la manière de ce que font déjà les géants du web avec leurs forks de PostgreSQL (pensez AlloyDB, AuroraDB, les forks de Google et d'Amazon du dit PostgreSQL). Au delà des paroles rassurantes et du _damage control_ des différents communicants, ce que cela veut dire exactement pour le projet reste à découvrir...
 
 ----
 

--- a/content/rdp/2026/rdp_2026-09-04.md
+++ b/content/rdp/2026/rdp_2026-09-04.md
@@ -141,7 +141,7 @@ Vous pouvez également vous replonger dans [l'article de 2025](../../articles/20
 
 ### DuckDB
 
-![logo Duckdb](https://cdn.geotribu.fr/img/logos-icones/logiciels_librairies//duckdb.png "logo DuckDB"{: .img-thumbnail-left }
+![logo Duckdb](https://cdn.geotribu.fr/img/logos-icones/logiciels_librairies/duckdb.png "logo DuckDB"{: .img-thumbnail-left }
 
 De manière peut-être un peu moins réjouissante, DuckLabs, l'entité derrière DuckDB, vient de se faire acquérir par Amazon. On nous garantie que le projet va rester open source, mais des doutes peuvent êtres soulevés sur les possibles reversement au projet communautaire des développements faits en interne pour AWS. Un peu à la manière de se que font déjà les géants du web avec leurs forks de PostgreSQL (pensez AlloyDB, AuroraDB, les forks de Google et d'Amazon du dit PostgreSQL). Au delà des paroles rassurantes et du damage control des différents communicants, ce que cela veut dire exactement pour le projet reste à découvrir...
 


### PR DESCRIPTION
Ajout news acqusition DuckLabs par Amazon